### PR TITLE
fix(workflow): stop training on stop action

### DIFF
--- a/src/controllers/workflow_controller.py
+++ b/src/controllers/workflow_controller.py
@@ -118,7 +118,8 @@ class WorkflowController(QObject):
     def stop(self):
         """停止工作流执行"""
         self._engine.stop()
-        self._event_bus.emit_status("工作流已停止")
+        # Stopping can be asynchronous (e.g., training node stops at batch/epoch boundary).
+        self._event_bus.emit_status("已请求停止工作流，正在等待当前任务结束...")
     
     def pause(self):
         """暂停工作流执行"""

--- a/src/core/event_bus.py
+++ b/src/core/event_bus.py
@@ -84,6 +84,7 @@ class EventBus(QObject):
     training_epoch_completed = pyqtSignal(int, int, dict)       # Epoch completed (current, total, metrics)
     training_finished = pyqtSignal(bool, str)                   # Training finished (success, message)
     training_stopped = pyqtSignal()                             # Training stopped
+    training_stop_with_checkpoint = pyqtSignal(str)             # Request stop + save checkpoint (path)
     
     # ===== Model Events =====
     model_loaded = pyqtSignal(object)                           # Model loaded (model)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -293,6 +293,7 @@ class MainWindow(QWidget):
         self._training_view.pause_requested.connect(self._on_pause_training)
         self._training_view.resume_requested.connect(self._on_resume_training)
         self._training_view.stop_requested.connect(self._on_stop_training)
+        self._training_view.stop_and_save_requested.connect(self._on_stop_training_and_save)
         
         # 工作流视图断点继续信号
         self._workflow_view.continue_requested.connect(self._on_continue_from_breakpoint)
@@ -345,14 +346,35 @@ class MainWindow(QWidget):
         """事件总线：工作流开始"""
         self.training_started.emit()
         self._workflow_view.reset_all_node_states()
+        # Ensure workflow run controls are enabled when a run starts.
+        try:
+            self._workflow_view._stop_btn.setEnabled(True)
+            self._workflow_view._stop_btn.setText("⏹️ 停止运行")
+            self._workflow_view._run_btn.setEnabled(False)
+        except Exception:
+            pass
     
     def _on_event_workflow_finished(self, success: bool, message: str):
         """事件总线：工作流完成"""
         if success:
             self.training_completed.emit({})
+        # Restore workflow run controls (stop may take time and temporarily disables buttons).
+        try:
+            self._workflow_view._run_btn.setEnabled(True)
+            self._workflow_view._stop_btn.setEnabled(False)
+            self._workflow_view._stop_btn.setText("⏹️ 停止运行")
+        except Exception:
+            pass
     
     def _on_event_workflow_error(self, error_msg: str):
         """事件总线：工作流错误"""
+        # Restore workflow run controls on error as well.
+        try:
+            self._workflow_view._run_btn.setEnabled(True)
+            self._workflow_view._stop_btn.setEnabled(False)
+            self._workflow_view._stop_btn.setText("⏹️ 停止运行")
+        except Exception:
+            pass
         QMessageBox.critical(self, "执行错误", error_msg)
     
     def _on_event_node_started(self, node_id: str):
@@ -507,6 +529,17 @@ class MainWindow(QWidget):
     
     def _on_stop_training(self):
         """停止训练"""
+        self._workflow_controller.stop()
+        self._training_controller.stop_training()
+
+    def _on_stop_training_and_save(self, checkpoint_path: str):
+        """Stop training and save a checkpoint before exiting training loop."""
+        try:
+            self._event_bus.training_stop_with_checkpoint.emit(checkpoint_path)
+        except Exception:
+            # Avoid breaking stop flow if UI emits a bad path
+            pass
+
         self._workflow_controller.stop()
         self._training_controller.stop_training()
     

--- a/src/ui/views/training_view.py
+++ b/src/ui/views/training_view.py
@@ -39,11 +39,13 @@ class TrainingView(QWidget):
         pause_requested: 请求暂停训练
         resume_requested: 请求恢复训练
         stop_requested: 请求停止训练
+        stop_and_save_requested: 请求停止训练并保存检查点 (path)
     """
     
     pause_requested = pyqtSignal()
     resume_requested = pyqtSignal()
     stop_requested = pyqtSignal()
+    stop_and_save_requested = pyqtSignal(str)
     
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -210,12 +212,17 @@ class TrainingView(QWidget):
         self._pause_btn.setEnabled(False)
         row1.addWidget(self._pause_btn)
         
-        self._stop_btn = QPushButton("⏹️ 停止")
+        self._stop_btn = QPushButton("⏹️ 停止训练")
         self._stop_btn.clicked.connect(self._on_stop)
         self._stop_btn.setEnabled(False)
         row1.addWidget(self._stop_btn)
+
+        self._stop_and_save_btn = QPushButton("💾 停止并保存检查点")
+        self._stop_and_save_btn.clicked.connect(self._on_stop_and_save)
+        self._stop_and_save_btn.setEnabled(False)
+        row1.addWidget(self._stop_and_save_btn)
         
-        for btn in [self._pause_btn, self._stop_btn]:
+        for btn in [self._pause_btn, self._stop_btn, self._stop_and_save_btn]:
             btn.setStyleSheet(f"""
                 QPushButton {{
                     background: {Styles.COLORS['surface1']};
@@ -282,6 +289,7 @@ class TrainingView(QWidget):
         
         self._pause_btn.setEnabled(True)
         self._stop_btn.setEnabled(True)
+        self._stop_and_save_btn.setEnabled(True)
         
         self._log_text.clear()
         self._log("训练开始...")
@@ -397,6 +405,7 @@ class TrainingView(QWidget):
         
         self._pause_btn.setEnabled(False)
         self._stop_btn.setEnabled(False)
+        self._stop_and_save_btn.setEnabled(False)
     
     def _on_pause_resume(self):
         """暂停/恢复"""
@@ -414,6 +423,25 @@ class TrainingView(QWidget):
     def _on_stop(self):
         """停止"""
         self.stop_requested.emit()
+
+    def _on_stop_and_save(self):
+        """Stop training and save checkpoint to a file chosen by user."""
+        from PyQt6.QtWidgets import QFileDialog
+        from datetime import datetime
+        import os
+
+        default_dir = "models"
+        default_name = f"checkpoint_{datetime.now().strftime('%Y%m%d_%H%M%S')}.keras"
+        default_path = os.path.join(default_dir, default_name)
+
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "保存检查点",
+            default_path,
+            "Keras Model (*.keras);;H5 Model (*.h5);;All Files (*)"
+        )
+        if path:
+            self.stop_and_save_requested.emit(path)
     
     def _log(self, message: str):
         """添加日志"""

--- a/src/ui/views/workflow_view.py
+++ b/src/ui/views/workflow_view.py
@@ -169,9 +169,10 @@ class WorkflowView(QWidget):
         self._run_btn.setStyleSheet(btn_style)
         normal_layout.addWidget(self._run_btn)
         
-        self._stop_btn = QPushButton("⏹️ 停止")
+        self._stop_btn = QPushButton("⏹️ 停止运行")
         self._stop_btn.clicked.connect(self._on_stop_workflow)
         self._stop_btn.setStyleSheet(btn_style)
+        self._stop_btn.setEnabled(False)  # Only enabled while a workflow is running
         normal_layout.addWidget(self._stop_btn)
         
         self._run_control_stack.addWidget(normal_widget)  # index 0
@@ -381,7 +382,23 @@ class WorkflowView(QWidget):
     
     def _on_stop_workflow(self):
         """停止工作流"""
-        if self._engine:
+        from src.core.event_bus import get_event_bus
+
+        # Immediate UI feedback: stopping can take time (e.g., waiting for training batch/epoch end).
+        if hasattr(self, "_stop_btn"):
+            self._stop_btn.setEnabled(False)
+            self._stop_btn.setText("⏳ 正在停止...")
+        if hasattr(self, "_run_btn"):
+            self._run_btn.setEnabled(False)
+
+        event_bus = get_event_bus()
+        event_bus.emit_status("正在停止工作流...（等待当前任务收尾）")
+        event_bus.training_stopped.emit()
+
+        controller = getattr(self, "_workflow_controller", None)
+        if controller is not None:
+            controller.stop()
+        elif self._engine:
             self._engine.stop()
     
     def _on_clear_workflow(self):

--- a/src/workflow/engine.py
+++ b/src/workflow/engine.py
@@ -239,12 +239,15 @@ class WorkflowEngine(QObject):
             for i, node_id in enumerate(execution_order):
                 # Check stop request
                 if self._stop_requested:
-                    return ExecutionResult(
+                    self.state = EngineState.STOPPED
+                    result = ExecutionResult(
                         success=False,
                         message="执行已停止",
                         execution_time=time.time() - start_time,
                         node_results=node_results
                     )
+                    self.workflow_finished.emit(result)
+                    return result
                 
                 # Check pause request
                 while self._pause_requested:
@@ -264,12 +267,14 @@ class WorkflowEngine(QObject):
                 
                 if not success:
                     self.state = EngineState.ERROR
-                    return ExecutionResult(
+                    result = ExecutionResult(
                         success=False,
                         message=f"节点 '{node.display_name}' 执行失败: {node.error_message}",
                         execution_time=time.time() - start_time,
                         node_results=node_results
                     )
+                    self.workflow_finished.emit(result)
+                    return result
                 
                 # Collect results
                 node_results[node_id] = {

--- a/src/workflow/nodes/training.py
+++ b/src/workflow/nodes/training.py
@@ -360,6 +360,8 @@ class TrainerNode(BaseNode):
             from tensorflow import keras
             from .data_source import AudioData
             from src.model_builder.model_graph import CompileConfig
+            from src.core.event_bus import get_event_bus
+            import os
             
             model = self.get_input_data("model")
             x_train = self.get_input_data("x_train")
@@ -434,7 +436,43 @@ class TrainerNode(BaseNode):
                 epoch_metrics = logs or {}
                 self.report_progress(progress, f"Epoch {current_epoch}/{total_epochs}", epoch_metrics)
             
-            callbacks.append(TrainingCallback(on_epoch_end=on_epoch_end))
+            class _TrainingStopAndSaveCallback(TrainingCallback):
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
+                    self._checkpoint_path: Optional[str] = None
+
+                def set_checkpoint_path(self, path: str):
+                    self._checkpoint_path = path
+
+                def on_train_end(self, logs=None):
+                    super().on_train_end(logs)
+                    if not self._checkpoint_path:
+                        return
+                    try:
+                        dir_path = os.path.dirname(self._checkpoint_path)
+                        if dir_path:
+                            os.makedirs(dir_path, exist_ok=True)
+                        # Save full model checkpoint (can be large).
+                        self.model.save(self._checkpoint_path)
+                    except Exception:
+                        # Do not raise from callback; training is already stopping.
+                        pass
+
+            training_callback = _TrainingStopAndSaveCallback(on_epoch_end=on_epoch_end)
+            callbacks.append(training_callback)
+
+            event_bus = get_event_bus()
+
+            def _on_training_stopped():
+                training_callback.stop_training()
+
+            def _on_training_stop_with_checkpoint(path: str):
+                if path:
+                    training_callback.set_checkpoint_path(path)
+                training_callback.stop_training()
+
+            event_bus.training_stopped.connect(_on_training_stopped)
+            event_bus.training_stop_with_checkpoint.connect(_on_training_stop_with_checkpoint)
             
             if self.get_parameter("early_stopping"):
                 callbacks.append(keras.callbacks.EarlyStopping(
@@ -445,15 +483,25 @@ class TrainerNode(BaseNode):
             
             # 训练
             self.report_status(f"开始训练: {total_epochs} epochs, batch_size={self.get_parameter('batch_size')}")
-            
-            history = model.fit(
-                X, Y,
-                epochs=total_epochs,
-                batch_size=self.get_parameter("batch_size"),
-                validation_data=validation_data,
-                callbacks=callbacks,
-                verbose=1
-            )
+
+            try:
+                history = model.fit(
+                    X, Y,
+                    epochs=total_epochs,
+                    batch_size=self.get_parameter("batch_size"),
+                    validation_data=validation_data,
+                    callbacks=callbacks,
+                    verbose=1
+                )
+            finally:
+                try:
+                    event_bus.training_stopped.disconnect(_on_training_stopped)
+                except TypeError:
+                    pass
+                try:
+                    event_bus.training_stop_with_checkpoint.disconnect(_on_training_stop_with_checkpoint)
+                except TypeError:
+                    pass
             
             self.set_output_data("trained_model", model)
             self.set_output_data("history", history.history)


### PR DESCRIPTION
## Summary

- Make workflow/training stop responsive by propagating stop requests to training callbacks.
- Add Stop and Save Checkpoint action in Training view.
- Ensure engine emits workflow_finished on stop/error so the UI restores controls.

## Related Issue

Fixes #11

## Test Plan

- [ ] Start a workflow with TrainerNode, click Stop run in Workflow view, confirm it stops and UI restores.
- [ ] In Training view click Stop training and verify it stops at batch/epoch boundary.
- [ ] In Training view click Stop and Save Checkpoint and verify the .keras/.h5 file is created.
