### PR TITLE
feat(ui): delete selected connections with Delete key

### DIFF
--- a/src/ui/graph_editor/base_items.py
+++ b/src/ui/graph_editor/base_items.py
@@ -104,11 +104,29 @@ class BaseConnectionItem(QGraphicsPathItem):
         target_port.connections.append(self)
         
         # 样式
-        color = line_color or Styles.COLORS['blue']
-        self.setPen(QPen(QColor(color), 2))
+        self._base_color = line_color or Styles.COLORS['blue']
+        self._selected_color = "#f5e0dc"
+        self._base_width = 2
+        self._selected_width = 3
+
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
+        self._update_pen()
         self.setZValue(-1)  # 在节点下方
         
         self.update_path()
+
+    def _update_pen(self):
+        """Update pen according to selection state."""
+        if self.isSelected():
+            self.setPen(QPen(QColor(self._selected_color), self._selected_width))
+        else:
+            self.setPen(QPen(QColor(self._base_color), self._base_width))
+
+    def itemChange(self, change, value):
+        """React to selection changes."""
+        if change == QGraphicsItem.GraphicsItemChange.ItemSelectedHasChanged:
+            self._update_pen()
+        return super().itemChange(change, value)
     
     def update_path(self):
         """更新贝塞尔曲线路径"""

--- a/src/ui/model_editor/model_graph_widget.py
+++ b/src/ui/model_editor/model_graph_widget.py
@@ -513,7 +513,29 @@ class ModelGraphWidget(QWidget):
         menu.exec(self._view.mapToGlobal(pos))
     
     def _delete_selected(self):
-        """删除选中的层（支持多选）"""
+        """Delete selected items.
+
+        Priority:
+        - Delete selected connection(s) if any
+        - Otherwise delete selected layer(s)
+        """
+        selected = list(self._scene.selectedItems())
+
+        # 1) Delete selected connections first
+        conn_items = [item for item in selected if isinstance(item, LayerConnectionItem)]
+        if conn_items:
+            for conn_item in list(conn_items):
+                if self.model_graph:
+                    self.model_graph.disconnect(
+                        conn_item.source_layer.layer.layer_id,
+                        conn_item.target_layer.layer.layer_id,
+                    )
+                self._scene.remove_connection_item(conn_item)
+
+            self.graph_changed.emit()
+            return
+
+        # 2) Delete selected layers (multi-select)
         layer_ids = self.get_selected_layer_ids()
         for layer_id in layer_ids:
             self.remove_layer(layer_id)

--- a/src/ui/node_editor/node_graph.py
+++ b/src/ui/node_editor/node_graph.py
@@ -683,15 +683,37 @@ class NodeGraphWidget(QWidget):
         menu.exec(self._view.mapToGlobal(pos))
     
     def _delete_selected(self):
-        """删除所有选中的节点"""
-        # 收集所有选中的节点ID
-        selected = self._scene.selectedItems()
-        node_ids = []
+        """Delete selected items.
+
+        Priority:
+        - Delete selected connection(s) if any
+        - Otherwise delete selected node(s)
+        """
+        selected = list(self._scene.selectedItems())
+
+        # 1) Delete selected connections first
+        conn_items = [item for item in selected if isinstance(item, ConnectionItem)]
+        if conn_items:
+            for conn_item in list(conn_items):
+                if self.workflow:
+                    connection = Connection(
+                        source_node_id=conn_item.source_node.node.node_id,
+                        source_port=conn_item.source_port.port_name,
+                        target_node_id=conn_item.target_node.node.node_id,
+                        target_port=conn_item.target_port.port_name,
+                    )
+                    self.workflow.remove_connection(connection)
+                self._scene.remove_connection_item(conn_item)
+
+            self.workflow_changed.emit()
+            return
+
+        # 2) Delete selected nodes
+        node_ids: List[str] = []
         for item in selected:
             if isinstance(item, NodeItem):
                 node_ids.append(item.node.node_id)
-        
-        # 逐一删除
+
         for node_id in node_ids:
             self.remove_node(node_id)
     


### PR DESCRIPTION
## Summary

- Make connection items selectable with a visible selected state.
- Support deleting selected connection(s) via Delete/Backspace in both Workflow and Model editors.
- Keep UI scene and underlying data models in sync (Workflow.connections / ModelGraph.connections).

## Related Issue

Closes #9
Refs: FEAT2026012901

## Test Plan

- [x] Manual: Workflow editor - select a connection and press Delete/Backspace
- [x] Manual: Model editor - select a connection and press Delete/Backspace
- [x] Manual: Mixed selection (node/layer + connection) deletes connections first
- [x] Manual: No selection -> no-op (no crash)