### PR TITLE
refactor(ui): reduce UI-domain coupling

### DIFF
--- a/src/controllers/navigation_controller.py
+++ b/src/controllers/navigation_controller.py
@@ -6,23 +6,19 @@ Responsible for navigation and switching logic between views within the applicat
 """
 
 import logging
-from enum import IntEnum
 from typing import Optional
 
 from PyQt6.QtCore import QObject, pyqtSignal
 
 from src.core.event_bus import get_event_bus
 from src.ui.i18n import tr_
+from src.controllers.view_types import ViewType
+from src.controllers.navigation_dto import (
+    MessageBoxSpec,
+    NodeDoubleClickContext,
+    NodeDoubleClickDecision,
+)
 logger = logging.getLogger(__name__)
-
-
-class ViewType(IntEnum):
-    """视图类型枚举"""
-    WORKFLOW = 0      # 工作流视图
-    MODEL = 1         # 模型视图
-    PREVIEW = 2       # 预览视图
-    TRAINING = 3      # 训练视图
-
 
 class NavigationController(QObject):
     """
@@ -170,33 +166,121 @@ class NavigationController(QObject):
         Returns:
             是否处理了双击事件
         """
-        # 训练相关节点
-        if category == "training":
-            if node_type == "trainer":
+        # Keep this legacy API, but delegate the decision to the unified implementation.
+        ctx = NodeDoubleClickContext(
+            node_id=node_id,
+            node_type=node_type,
+            category=category,
+            display_name=node_id,
+            has_output=has_output,
+            outputs=outputs or {},
+        )
+        decision = self.decide_node_double_click(ctx)
+        return decision.handled
+
+    def decide_node_double_click(self, ctx: NodeDoubleClickContext) -> NodeDoubleClickDecision:
+        """
+        Decide what to do when a workflow node is double-clicked.
+
+        This is a UI-agnostic decision API. It can trigger view switching via existing
+        controller methods, and returns a `NodeDoubleClickDecision` describing any
+        additional UI actions the caller should perform (message box, preview payload, etc.).
+        """
+        # Special cases first (kept consistent with legacy MainWindow logic).
+        if ctx.node_type == "save_model":
+            if ctx.has_output:
+                model_path = (ctx.outputs or {}).get("model_path")
+                if model_path:
+                    return NodeDoubleClickDecision(
+                        handled=True,
+                        message_box=MessageBoxSpec(
+                            level="info",
+                            title=tr_("Model save path"),
+                            message=tr_("Model saved to:\n{path}").format(path=model_path),
+                        ),
+                    )
+            return NodeDoubleClickDecision(handled=True, show_not_run_tip=True)
+
+        if ctx.category == "control" and ctx.node_type == "loop":
+            return NodeDoubleClickDecision(
+                handled=True,
+                message_box=MessageBoxSpec(
+                    level="info",
+                    title=tr_("Info"),
+                    message=tr_(
+                        "Loop node [{name}] cannot be previewed.\n"
+                        "Please preview a specific processing node inside the loop."
+                    ).format(name=ctx.display_name),
+                ),
+            )
+
+        if ctx.node_type == "label_file":
+            if ctx.has_output:
+                labels = (ctx.outputs or {}).get("labels")
+                if labels:
+                    if isinstance(labels, (list, dict)):
+                        label_count = len(labels)
+                    else:
+                        label_count = 1
+                    return NodeDoubleClickDecision(
+                        handled=True,
+                        message_box=MessageBoxSpec(
+                            level="info",
+                            title=tr_("Label data"),
+                            message=tr_(
+                                "Loaded {count} label(s).\n"
+                                "Label data cannot be visualized for preview."
+                            ).format(count=label_count),
+                        ),
+                    )
+            return NodeDoubleClickDecision(handled=True, show_not_run_tip=True)
+
+        if ctx.node_type == "show_history" and ctx.has_output:
+            history = (ctx.outputs or {}).get("history")
+            if history is not None:
+                # View should inject this to TrainingView before switching.
                 self.switch_to_training()
-                return True
-            elif node_type == "load_model":
-                # 跳转到预览视图显示模型 summary
-                if has_output and outputs:
-                    self._selected_node_id = node_id
-                    self.switch_to_preview()
-                    return True
-                return False
-            elif node_type == "show_history":
+                return NodeDoubleClickDecision(
+                    handled=True,
+                    switch_to=ViewType.TRAINING,
+                    training_history=history,
+                )
+
+        # Training-related nodes.
+        if ctx.category == "training":
+            if ctx.node_type in ("trainer", "show_history"):
                 self.switch_to_training()
-                return True
-        
-        # 控制流节点通常不需要预览
-        if category == "control":
-            return False
-        
-        # 其他节点：如果有输出数据则跳转预览
-        if has_output and outputs:
-            self._selected_node_id = node_id
+                return NodeDoubleClickDecision(handled=True, switch_to=ViewType.TRAINING)
+
+            # For other training nodes, if they have output, go to preview.
+            if ctx.has_output and ctx.outputs:
+                self._selected_node_id = ctx.node_id
+                self.switch_to_preview()
+                return NodeDoubleClickDecision(
+                    handled=True,
+                    switch_to=ViewType.PREVIEW,
+                    preview_payload=(ctx.node_id, ctx.display_name, ctx.outputs),
+                )
+            return NodeDoubleClickDecision(handled=True, show_not_run_tip=True)
+
+        # Control nodes: do not preview (legacy behavior).
+        if ctx.category == "control":
+            return NodeDoubleClickDecision(handled=False)
+
+        # Default fallback: if it has output data, preview it; otherwise show tip.
+        if not ctx.has_output:
+            return NodeDoubleClickDecision(handled=True, show_not_run_tip=True)
+
+        if ctx.outputs:
+            self._selected_node_id = ctx.node_id
             self.switch_to_preview()
-            return True
-        
-        return False
+            return NodeDoubleClickDecision(
+                handled=True,
+                switch_to=ViewType.PREVIEW,
+                preview_payload=(ctx.node_id, ctx.display_name, ctx.outputs),
+            )
+
+        return NodeDoubleClickDecision(handled=False)
     
     def _on_node_selected(self, node_id: str):
         """节点选中事件"""

--- a/src/controllers/navigation_dto.py
+++ b/src/controllers/navigation_dto.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from .view_types import ViewType
+
+
+@dataclass(frozen=True)
+class NodeDoubleClickContext:
+    """Context required to decide what to do on node double-click."""
+
+    node_id: str
+    node_type: str
+    category: str
+    display_name: str
+    has_output: bool
+    outputs: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class MessageBoxSpec:
+    """
+    UI message box request produced by a controller.
+
+    `title` and `message` should already be translated via `tr_()` by the controller.
+    """
+
+    level: str  # "info" | "warning"
+    title: str
+    message: str
+
+
+@dataclass(frozen=True)
+class NodeDoubleClickDecision:
+    """Decision for node double-click handling."""
+
+    handled: bool = False
+    switch_to: Optional[ViewType] = None
+    preview_payload: Optional[Tuple[str, str, Dict[str, Any]]] = None  # (node_id, node_name, outputs)
+    training_history: Optional[Any] = None
+    message_box: Optional[MessageBoxSpec] = None
+    show_not_run_tip: bool = False
+

--- a/src/controllers/training_controller.py
+++ b/src/controllers/training_controller.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional
 from PyQt6.QtCore import QObject, pyqtSignal
 
 from src.core.event_bus import get_event_bus
+from src.services.training_params_service import TrainingParamsService
 from src.ui.i18n import tr_
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,20 @@ class TrainingController(QObject):
         )
         
         logger.info(f"Training started: {total_epochs} epochs")
+
+    def start_training_for_workflow(self, workflow, default_epochs: int = 20) -> int:
+        """
+        Derive training parameters from a workflow and start training tracking.
+
+        Returns:
+            The derived total epochs.
+        """
+        total_epochs = TrainingParamsService.derive_total_epochs(
+            workflow,
+            default_epochs=default_epochs,
+        )
+        self.start_training(total_epochs)
+        return total_epochs
     
     def update_epoch(self, current: int, total: int, metrics: Dict[str, Any]):
         """

--- a/src/controllers/view_types.py
+++ b/src/controllers/view_types.py
@@ -1,0 +1,11 @@
+from enum import IntEnum
+
+
+class ViewType(IntEnum):
+    """View type enum shared across controllers and UI."""
+
+    WORKFLOW = 0
+    MODEL = 1
+    PREVIEW = 2
+    TRAINING = 3
+

--- a/src/controllers/workflow_controller.py
+++ b/src/controllers/workflow_controller.py
@@ -88,8 +88,22 @@ class WorkflowController(QObject):
         """
         self._workflow = workflow
         self._engine.set_workflow(workflow)
+
+    def validate_workflow(self, workflow: Workflow) -> tuple[bool, list[str]]:
+        """
+        Validate a workflow and return raw errors without side effects.
+
+        This API is intended for UI to present validation results (e.g. warning dialog)
+        without coupling UI to domain validation details.
+        """
+        try:
+            valid, errors = workflow.validate()
+            return bool(valid), list(errors or [])
+        except Exception as e:
+            # Keep a stable return shape; callers decide how to present the error.
+            return False, [str(e)]
     
-    def run(self) -> bool:
+    def run(self, *, validate: bool = True) -> bool:
         """
         运行当前工作流
         
@@ -100,14 +114,14 @@ class WorkflowController(QObject):
             self._event_bus.emit_status(tr_("No workflow to run"))
             return False
         
-        # 验证工作流
-        valid, errors = self._workflow.validate()
-        if not valid:
-            error_msg = tr_("Workflow validation failed:\n{errors}").format(
-                errors="\n".join(errors)
-            )
-            self._event_bus.workflow_error.emit(error_msg)
-            return False
+        if validate:
+            valid, errors = self.validate_workflow(self._workflow)
+            if not valid:
+                error_msg = tr_("Workflow validation failed:\n{errors}").format(
+                    errors="\n".join(errors)
+                )
+                self._event_bus.workflow_error.emit(error_msg)
+                return False
         
         # 开始执行
         self._event_bus.emit_status(tr_("Starting workflow..."))

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,4 @@
+"""
+Application services (infrastructure-facing, UI-agnostic).
+"""
+

--- a/src/services/system_info_service.py
+++ b/src/services/system_info_service.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from importlib import import_module
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GPUInfo:
+    """GPU detection result with a stable shape."""
+
+    available: bool
+    device_count: int
+    device_names: List[str]
+    backend: str  # e.g. "tensorflow", "missing", "error"
+    error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class MemoryInfo:
+    """Memory information with a stable shape."""
+
+    total_gb: float
+    used_gb: float
+    backend: str  # e.g. "psutil", "missing", "error"
+    error: Optional[str] = None
+
+
+class SystemInfoService:
+    """
+    Provide system/environment information for the application.
+
+    Notes:
+    - This module must remain UI-agnostic.
+    - Heavy dependencies (e.g. TensorFlow) are imported lazily and results are cached.
+    """
+
+    def __init__(self) -> None:
+        self._gpu_info_cache: Optional[GPUInfo] = None
+
+    def get_gpu_info(self, *, force_refresh: bool = False) -> GPUInfo:
+        """
+        Detect GPU availability via TensorFlow if installed.
+
+        Returns a stable `GPUInfo` shape even when TensorFlow is missing or errors.
+        """
+        if self._gpu_info_cache is not None and not force_refresh:
+            return self._gpu_info_cache
+
+        try:
+            tf = import_module("tensorflow")
+        except Exception as e:
+            info = GPUInfo(
+                available=False,
+                device_count=0,
+                device_names=[],
+                backend="missing",
+                error=str(e),
+            )
+            self._gpu_info_cache = info
+            return info
+
+        try:
+            gpus = tf.config.list_physical_devices("GPU")
+            names: List[str] = []
+            for gpu in gpus:
+                name = getattr(gpu, "name", None)
+                names.append(name if name else str(gpu))
+            info = GPUInfo(
+                available=len(gpus) > 0,
+                device_count=len(gpus),
+                device_names=names,
+                backend="tensorflow",
+                error=None,
+            )
+            self._gpu_info_cache = info
+            return info
+        except Exception as e:
+            logger.exception("GPU detection failed.")
+            info = GPUInfo(
+                available=False,
+                device_count=0,
+                device_names=[],
+                backend="error",
+                error=str(e),
+            )
+            self._gpu_info_cache = info
+            return info
+
+    def get_memory_info(self) -> MemoryInfo:
+        """
+        Return memory usage via psutil if installed.
+
+        If psutil is missing or errors, returns a stable `MemoryInfo` shape.
+        """
+        try:
+            psutil = import_module("psutil")
+        except Exception as e:
+            return MemoryInfo(total_gb=0.0, used_gb=0.0, backend="missing", error=str(e))
+
+        try:
+            memory = psutil.virtual_memory()
+            used_gb = float(memory.used) / (1024.0**3)
+            total_gb = float(memory.total) / (1024.0**3)
+            return MemoryInfo(total_gb=total_gb, used_gb=used_gb, backend="psutil", error=None)
+        except Exception as e:
+            logger.exception("Memory detection failed.")
+            return MemoryInfo(total_gb=0.0, used_gb=0.0, backend="error", error=str(e))
+

--- a/src/services/training_params_service.py
+++ b/src/services/training_params_service.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class TrainingParamsService:
+    """Derive training-related parameters from a workflow (UI-agnostic)."""
+
+    @staticmethod
+    def derive_total_epochs(workflow: Any, *, default_epochs: int = 20) -> int:
+        """
+        Derive total epochs from workflow nodes.
+
+        Current rule (kept consistent with legacy UI logic):
+        - Start from `default_epochs`
+        - Iterate nodes in insertion order
+        - Use the first truthy `node.get_parameter(\"epochs\")` value if present
+        - Fall back to `default_epochs` on any error
+        """
+        total_epochs = default_epochs
+        nodes = getattr(workflow, "nodes", None)
+        if not isinstance(nodes, dict):
+            return total_epochs
+
+        for node in nodes.values():
+            get_parameter = getattr(node, "get_parameter", None)
+            if not callable(get_parameter):
+                continue
+            try:
+                epochs = get_parameter("epochs")
+            except Exception:
+                continue
+
+            if not epochs:
+                continue
+
+            try:
+                epochs_int = int(epochs)
+            except Exception:
+                logger.debug("Invalid epochs value: %r", epochs)
+                continue
+
+            if epochs_int > 0:
+                total_epochs = epochs_int
+                break
+
+        return total_epochs
+

--- a/src/ui/dialogs/settings_dialog.py
+++ b/src/ui/dialogs/settings_dialog.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
 )
 
 from src.ui.i18n import tr_
+from src.services.system_info_service import SystemInfoService
 class SettingsDialog(QDialog):
     """应用设置对话框"""
     
@@ -19,6 +20,7 @@ class SettingsDialog(QDialog):
     def __init__(self, parent=None, current_settings: dict = None):
         super().__init__(parent)
         self.current_settings = current_settings or {}
+        self._system_info_service = SystemInfoService()
         self._init_ui()
         self._load_settings()
     
@@ -322,25 +324,21 @@ class SettingsDialog(QDialog):
         return widget
     
     def _detect_gpu(self):
-        """检测GPU"""
-        try:
-            import tensorflow as tf
-            gpus = tf.config.list_physical_devices('GPU')
-            if gpus:
-                info_text = tr_("Detected {count} GPU(s):\n").format(count=len(gpus))
-                for i, gpu in enumerate(gpus):
-                    info_text += f"  {i+1}. {gpu.name}\n"
-                self.gpu_info_label.setText(info_text)
-                self.gpu_info_label.setStyleSheet("color: #a6e3a1;")
-            else:
-                self.gpu_info_label.setText(
-                    tr_("No GPU detected. Training will use CPU.")
-                )
-                self.gpu_info_label.setStyleSheet("color: #f9e2af;")
-        except Exception as e:
-            self.gpu_info_label.setText(
-                tr_("GPU detection error: {error}").format(error=str(e))
-            )
+        """Detect GPU and update the GPU info label."""
+        info = self._system_info_service.get_gpu_info(force_refresh=True)
+        if info.available:
+            info_text = tr_("Detected {count} GPU(s):\n").format(count=info.device_count)
+            for i, name in enumerate(info.device_names):
+                info_text += f"  {i+1}. {name}\n"
+            self.gpu_info_label.setText(info_text)
+            self.gpu_info_label.setStyleSheet("color: #a6e3a1;")
+            return
+
+        if info.backend == "tensorflow":
+            self.gpu_info_label.setText(tr_("No GPU detected. Training will use CPU."))
+            self.gpu_info_label.setStyleSheet("color: #f9e2af;")
+        else:
+            self.gpu_info_label.setText(tr_("GPU detection error: {error}").format(error=info.error or "unknown"))
             self.gpu_info_label.setStyleSheet("color: #f38ba8;")
     
     def _browse_model_path(self):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -3,7 +3,7 @@
 Main Window Interface
 
 Node-based workflow editor with multi-view switching support.
-使用控制器模式分离业务逻辑，使用事件总线解耦组件通信。
+Uses controller pattern to separate business logic and an event bus to decouple component communication.
 """
 
 import logging
@@ -16,10 +16,13 @@ from PyQt6.QtWidgets import (
     QPushButton, QStackedWidget, QToolBar, QVBoxLayout, QWidget
 )
 
-from src.controllers.navigation_controller import NavigationController, ViewType
+from src.controllers.navigation_controller import NavigationController
+from src.controllers.view_types import ViewType
 from src.controllers.training_controller import TrainingController
 from src.controllers.workflow_controller import WorkflowController
 from src.core.event_bus import get_event_bus
+from src.services.system_info_service import SystemInfoService
+from src.controllers.navigation_dto import NodeDoubleClickContext
 from src.ui.i18n import tr_
 from src.ui.styles import Styles
 from src.ui.views.model_builder_view import ModelBuilderView
@@ -34,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class ViewButton(QPushButton):
-    """视图切换按钮"""
+    """View switch button."""
     
     def __init__(self, text: str, icon: str = "", parent=None):
         super().__init__(f"{icon} {text}" if icon else text, parent)
@@ -66,16 +69,16 @@ class ViewButton(QPushButton):
 
 class MainWindow(QWidget):
     """
-    主窗口组件
-    
-    采用多视图切换布局，支持：
-    - 工作流视图：节点编辑器
-    - 模型视图：可视化模型搭建
-    - 预览视图：数据可视化
-    - 训练视图：训练监控
+    Main window widget.
+
+    Provides multi-view switching:
+    - Workflow view: node editor
+    - Model view: visual model builder
+    - Preview view: data visualization
+    - Training view: training monitor
     """
     
-    # 信号定义
+    # Signals
     workflow_changed = pyqtSignal()
     training_started = pyqtSignal()
     training_stopped = pyqtSignal()
@@ -84,21 +87,24 @@ class MainWindow(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         
-        # 事件总线
+        # Event bus
         self._event_bus = get_event_bus()
+
+        # System/environment information service (UI-agnostic).
+        self._system_info_service = SystemInfoService()
         
-        # 工作流
+        # Workflow
         self._workflow: Optional[Workflow] = None
         
-        # 控制器（Engine 由 WorkflowController 内部管理）
+        # Controllers (Engine is managed inside WorkflowController)
         self._workflow_controller = WorkflowController()
         self._training_controller = TrainingController()
         self._navigation_controller = NavigationController()
         
-        # 当前模型（兼容旧代码）
+        # Current model (legacy compatibility)
         self.current_model = None
         
-        # 当前选中的节点ID（用于预览视图切换时更新）
+        # Currently selected node id (for preview refresh on view switch)
         self._selected_node_id: Optional[str] = None
         
         self._init_ui()
@@ -107,7 +113,7 @@ class MainWindow(QWidget):
         self._apply_styles()
         self._start_resource_monitor()
         
-        # 创建默认工作流
+        # Create default workflow
         self._create_default_workflow()
     
     def _init_ui(self):
@@ -233,7 +239,7 @@ class MainWindow(QWidget):
         
         layout.addWidget(status_frame)
         
-        # 检测GPU
+        # Detect GPU once at startup.
         self._detect_gpu()
     
     def _create_separator(self) -> QLabel:
@@ -243,42 +249,37 @@ class MainWindow(QWidget):
         return sep
     
     def _detect_gpu(self):
-        """检测GPU状态"""
-        try:
-            import tensorflow as tf
-            gpus = tf.config.list_physical_devices('GPU')
-            if gpus:
-                self.gpu_status.setText(
-                    tr_("GPU: {count} available").format(count=len(gpus))
-                )
-                self.gpu_status.setStyleSheet(f"color: {Styles.COLORS['green']};")
-            else:
-                self.gpu_status.setText(tr_("GPU: CPU only"))
-                self.gpu_status.setStyleSheet(f"color: {Styles.COLORS['yellow']};")
-        except Exception:
+        """Update the GPU status label."""
+        info = self._system_info_service.get_gpu_info()
+        if info.available:
+            self.gpu_status.setText(tr_("GPU: {count} available").format(count=info.device_count))
+            self.gpu_status.setStyleSheet(f"color: {Styles.COLORS['green']};")
+            return
+
+        # Not available, differentiate between "no GPU" and "unknown/error".
+        if info.backend in ("tensorflow",):
+            self.gpu_status.setText(tr_("GPU: CPU only"))
+            self.gpu_status.setStyleSheet(f"color: {Styles.COLORS['yellow']};")
+        else:
             self.gpu_status.setText(tr_("GPU: Unknown"))
             self.gpu_status.setStyleSheet(f"color: {Styles.COLORS['overlay0']};")
     
     def _start_resource_monitor(self):
-        """启动资源监控"""
+        """Start periodic resource monitoring for the status bar."""
         self.resource_timer = QTimer()
         self.resource_timer.timeout.connect(self._update_resource_status)
         self.resource_timer.start(5000)
     
     def _update_resource_status(self):
-        """更新资源状态"""
-        try:
-            import psutil  # type: ignore[import-not-found]
-            memory = psutil.virtual_memory()
-            used_gb = memory.used / (1024 ** 3)
-            total_gb = memory.total / (1024 ** 3)
+        """Update memory status in the status bar."""
+        info = self._system_info_service.get_memory_info()
+        if info.backend == "psutil" and info.total_gb > 0:
             self.memory_status.setText(
-                tr_("Memory: {used:.1f}/{total:.1f}GB").format(
-                    used=used_gb, total=total_gb
-                )
+                tr_("Memory: {used:.1f}/{total:.1f}GB").format(used=info.used_gb, total=info.total_gb)
             )
-        except ImportError:
-            pass
+            return
+
+        # Keep the previous value if detection is not available.
     
     def _init_connections(self):
         """
@@ -350,38 +351,35 @@ class MainWindow(QWidget):
         self._preview_view.set_node_data(node_id, node_name, outputs)
     
     def _on_event_workflow_started(self):
-        """事件总线：工作流开始"""
+        """EventBus: workflow started."""
         self.training_started.emit()
         self._workflow_view.reset_all_node_states()
-        # Ensure workflow run controls are enabled when a run starts.
-        try:
-            self._workflow_view._stop_btn.setEnabled(True)
-            self._workflow_view._stop_btn.setText(tr_("⏹️ Stop"))
-            self._workflow_view._run_btn.setEnabled(False)
-        except Exception:
-            pass
+        # Ensure workflow run controls are updated when a run starts.
+        self._workflow_view.set_run_controls_state(
+            run_enabled=False,
+            stop_enabled=True,
+            stop_text=tr_("⏹️ Stop"),
+        )
     
     def _on_event_workflow_finished(self, success: bool, message: str):
-        """事件总线：工作流完成"""
+        """EventBus: workflow finished."""
         if success:
             self.training_completed.emit({})
         # Restore workflow run controls (stop may take time and temporarily disables buttons).
-        try:
-            self._workflow_view._run_btn.setEnabled(True)
-            self._workflow_view._stop_btn.setEnabled(False)
-            self._workflow_view._stop_btn.setText(tr_("⏹️ Stop"))
-        except Exception:
-            pass
+        self._workflow_view.set_run_controls_state(
+            run_enabled=True,
+            stop_enabled=False,
+            stop_text=tr_("⏹️ Stop"),
+        )
     
     def _on_event_workflow_error(self, error_msg: str):
-        """事件总线：工作流错误"""
+        """EventBus: workflow error."""
         # Restore workflow run controls on error as well.
-        try:
-            self._workflow_view._run_btn.setEnabled(True)
-            self._workflow_view._stop_btn.setEnabled(False)
-            self._workflow_view._stop_btn.setText(tr_("⏹️ Stop"))
-        except Exception:
-            pass
+        self._workflow_view.set_run_controls_state(
+            run_enabled=True,
+            stop_enabled=False,
+            stop_text=tr_("⏹️ Stop"),
+        )
         QMessageBox.critical(self, tr_("Execution error"), error_msg)
     
     def _on_event_node_started(self, node_id: str):
@@ -499,14 +497,17 @@ class MainWindow(QWidget):
         self._preview_view.set_node_data(node_id, node.display_name, outputs)
     
     def _on_run_workflow(self):
-        """运行工作流"""
+        """Handle workflow run request from the UI."""
         workflow = self._workflow_view.get_workflow()
         if not workflow:
             QMessageBox.warning(self, tr_("Warning"), tr_("No runnable workflow."))
             return
         
-        # 验证工作流
-        valid, errors = workflow.validate()
+        # Update controller's workflow first so downstream calls have a consistent source of truth.
+        self._workflow_controller.set_workflow(workflow)
+
+        # Validate via controller (UI should not call domain validation directly).
+        valid, errors = self._workflow_controller.validate_workflow(workflow)
         if not valid:
             QMessageBox.warning(
                 self,
@@ -514,27 +515,12 @@ class MainWindow(QWidget):
                 tr_("Workflow validation failed:\n") + "\n".join(errors),
             )
             return
-        
-        # 更新控制器的工作流
-        self._workflow_controller.set_workflow(workflow)
-        
-        # 尝试从工作流中找到 TrainerNode 获取 epochs 数量
-        total_epochs = 20  # 默认值
-        for node in workflow.nodes.values():
-            if hasattr(node, 'get_parameter'):
-                try:
-                    epochs = node.get_parameter("epochs")
-                    if epochs:
-                        total_epochs = epochs
-                        break
-                except:
-                    pass
-        
-        # 通知训练控制器
-        self._training_controller.start_training(total_epochs)
+
+        # Notify training controller using derived params (UI should not traverse nodes).
+        self._training_controller.start_training_for_workflow(workflow, default_epochs=20)
         
         # 通过控制器执行工作流
-        success = self._workflow_controller.run()
+        success = self._workflow_controller.run(validate=False)
         if not success:
             self._training_controller.finish_training(False, tr_("Startup failed"))
     
@@ -646,12 +632,12 @@ class MainWindow(QWidget):
     
     def _on_node_progress(self, node_id: str, progress: float, data_json: str):
         """
-        节点内部进度更新（如训练epoch进度）
+        Node internal progress update (e.g. training epoch progress).
         
         Args:
-            node_id: 节点ID
-            progress: 进度值 (0.0 ~ 1.0)
-            data_json: JSON格式的metrics数据
+            node_id: Node ID
+            progress: Progress value (0.0 ~ 1.0)
+            data_json: Metrics payload in JSON format
         """
         import json
         
@@ -663,19 +649,14 @@ class MainWindow(QWidget):
         except (json.JSONDecodeError, TypeError):
             metrics = {}
         
-        # 获取 TrainerNode 的 epochs 参数
-        workflow = self._workflow_view.get_workflow()
-        total_epochs = 20  # 默认值
-        
-        if workflow:
-            node = workflow.get_node(node_id)
-            if node and hasattr(node, 'get_parameter'):
-                try:
-                    total_epochs = node.get_parameter("epochs") or 20
-                except:
-                    pass
-        
-        current_epoch = int(round(progress * total_epochs))
+        # Do not read business parameters from workflow nodes in the UI layer.
+        total_epochs = self._training_controller.total_epochs or 20
+
+        epoch_from_metrics = metrics.get("epoch")
+        if isinstance(epoch_from_metrics, (int, float)):
+            current_epoch = int(epoch_from_metrics)
+        else:
+            current_epoch = int(round(progress * total_epochs))
         
         # 更新训练视图
         self._training_view.update_epoch(current_epoch, total_epochs, metrics)
@@ -725,8 +706,8 @@ class MainWindow(QWidget):
         self._workflow_view.show_breakpoint_mode(True, node_name)
     
     def _on_continue_from_breakpoint(self):
-        """从断点继续执行"""
-        logger.info("用户请求从断点继续执行")
+        """Continue from a breakpoint."""
+        logger.info("User requested to continue from breakpoint")
         
         # 隐藏继续按钮
         self._workflow_view.show_breakpoint_mode(False)
@@ -736,13 +717,11 @@ class MainWindow(QWidget):
     
     def _on_node_double_clicked(self, node_id: str):
         """
-        节点双击处理
-        
-        根据节点类型和运行状态跳转到相应视图，委托给导航控制器处理通用逻辑。
+        Handle node double-click.
+
+        The UI should only gather context and execute UI actions. Routing/decision
+        logic is handled by the navigation controller.
         """
-        from src.workflow.node_base import NodeCategory
-        from src.workflow.port import DataType
-        
         workflow = self._workflow_view.get_workflow()
         if not workflow:
             return
@@ -763,83 +742,37 @@ class MainWindow(QWidget):
             for port_name, port in node.outputs.items()
         }
         
-        node_type = node.node_type
-        category = node.category
-        
-        # === 特殊节点处理 ===
-        
-        # 训练历史节点 - 需要特殊处理设置历史数据
-        if node_type == "show_history" and has_output_data:
-            history_port = node.outputs.get("history")
-            if history_port and history_port.data:
-                self._training_view.set_history(history_port.data)
-        
-        # 保存模型节点 - 显示保存路径信息
-        if node_type == "save_model":
-            if has_output_data:
-                model_path_port = node.outputs.get("model_path")
-                if model_path_port and model_path_port.data:
-                    QMessageBox.information(
-                        self,
-                        tr_("Model save path"),
-                        tr_("Model saved to:\n{path}").format(path=model_path_port.data),
-                    )
-                    return
-            self._show_not_run_tip(node)
-            return
-        
-        # 控制流节点
-        if category == NodeCategory.CONTROL and node_type == "loop":
-            QMessageBox.information(
-                self,
-                tr_("Info"),
-                tr_(
-                    "Loop node [{name}] cannot be previewed.\n"
-                    "Please preview a specific processing node inside the loop."
-                ).format(name=node.display_name),
-            )
-            return
-        
-        # 标签节点
-        if node_type == "label_file":
-            if has_output_data:
-                labels_port = node.outputs.get("labels")
-                if labels_port and labels_port.data:
-                    label_count = len(labels_port.data) if isinstance(labels_port.data, (list, dict)) else 1
-                    QMessageBox.information(
-                        self,
-                        tr_("Label data"),
-                        tr_(
-                            "Loaded {count} label(s).\n"
-                            "Label data cannot be visualized for preview."
-                        ).format(count=label_count),
-                    )
-                    return
-            self._show_not_run_tip(node)
-            return
-        
-        # === 使用导航控制器处理通用逻辑 ===
-        handled = self._navigation_controller.handle_node_double_click(
+        ctx = NodeDoubleClickContext(
             node_id=node_id,
-            node_type=node_type,
-            category=category.value if hasattr(category, 'value') else str(category),
+            node_type=node.node_type,
+            category=node.category.value if hasattr(node.category, "value") else str(node.category),
+            display_name=node.display_name,
             has_output=has_output_data,
-            outputs=outputs
+            outputs=outputs,
         )
-        
-        if handled:
-            # 导航控制器已处理，如果是预览则设置数据
-            if self._navigation_controller.current_view == ViewType.PREVIEW:
-                self._preview_view.set_node_data(node_id, node.display_name, outputs)
-            return
-        
-        # === 通用处理：检查是否有数据 ===
-        if not has_output_data:
+
+        decision = self._navigation_controller.decide_node_double_click(ctx)
+
+        if decision.show_not_run_tip:
             self._show_not_run_tip(node)
             return
-        
-        # === 根据输出数据类型跳转预览 ===
-        self._switch_to_preview_for_node(node_id, node)
+
+        if decision.message_box is not None:
+            spec = decision.message_box
+            if spec.level == "warning":
+                QMessageBox.warning(self, spec.title, spec.message)
+            else:
+                QMessageBox.information(self, spec.title, spec.message)
+            return
+
+        if decision.training_history is not None:
+            self._training_view.set_history(decision.training_history)
+
+        if decision.preview_payload is not None:
+            preview_node_id, preview_node_name, preview_outputs = decision.preview_payload
+            self._selected_node_id = preview_node_id
+            self._preview_view.set_node_data(preview_node_id, preview_node_name, preview_outputs)
+            return
     
     def _show_not_run_tip(self, node):
         """显示节点未运行提示"""
@@ -851,52 +784,6 @@ class MainWindow(QWidget):
                 "Click \"Run\" to execute the workflow first."
             ).format(name=node.display_name),
         )
-    
-    def _switch_to_preview_for_node(self, node_id: str, node):
-        """切换到预览视图并显示节点数据"""
-        from src.workflow.port import DataType
-        
-        # 切换到预览视图
-        self._preview_btn.setChecked(True)
-        self._view_stack.setCurrentWidget(self._preview_view)
-        
-        # 收集输出数据
-        outputs = {
-            port_name: port.data
-            for port_name, port in node.outputs.items()
-        }
-        
-        # 确定数据类型并更新状态
-        primary_port = list(node.outputs.values())[0] if node.outputs else None
-        if primary_port:
-            data_type = primary_port.data_type
-            type_desc = self._get_data_type_description(data_type)
-            self.status_label.setText(
-                tr_("Preview {name} - {type}").format(
-                    name=node.display_name, type=type_desc
-                )
-            )
-        
-        # 更新预览
-        self._selected_node_id = node_id
-        self._preview_view.set_node_data(node_id, node.display_name, outputs)
-    
-    def _get_data_type_description(self, data_type) -> str:
-        """获取数据类型的描述"""
-        from src.workflow.port import DataType
-        
-        descriptions = {
-            DataType.AUDIO: tr_("Audio waveform"),
-            DataType.FEATURE_1D: tr_("1D feature curve"),
-            DataType.FEATURE_2D: tr_("2D feature map"),
-            DataType.FEATURE: tr_("Feature data"),
-            DataType.MODEL: tr_("Model"),
-            DataType.METRICS: tr_("Metrics"),
-            DataType.LABEL: tr_("Label data"),
-            DataType.ANY: tr_("Data"),
-            DataType.TRIGGER: tr_("Trigger"),
-        }
-        return descriptions.get(data_type, tr_("Data"))
     
     # ===== 兼容旧接口 =====
     

--- a/src/ui/views/workflow_view.py
+++ b/src/ui/views/workflow_view.py
@@ -390,12 +390,33 @@ class WorkflowView(QWidget):
             except Exception:
                 pass
     
+    def set_run_controls_state(
+        self,
+        *,
+        run_enabled: bool,
+        stop_enabled: bool,
+        stop_text: Optional[str] = None,
+    ) -> None:
+        """
+        Update the workflow Run/Stop controls state.
+
+        This is a public API for other UI components (e.g. MainWindow) to update
+        run controls without accessing private widget members like `_run_btn`
+        or `_stop_btn`.
+        """
+        if hasattr(self, "_run_btn"):
+            self._run_btn.setEnabled(run_enabled)
+        if hasattr(self, "_stop_btn"):
+            self._stop_btn.setEnabled(stop_enabled)
+            if stop_text is not None:
+                self._stop_btn.setText(stop_text)
+
     def _on_run_workflow(self):
-        """运行工作流"""
+        """Request to run the workflow."""
         self.run_requested.emit()
     
     def _on_stop_workflow(self):
-        """停止工作流"""
+        """Request to stop the workflow."""
         from src.core.event_bus import get_event_bus
 
         # Immediate UI feedback: stopping can take time (e.g., waiting for training batch/epoch end).

--- a/src/ui/widgets/preview/audio_preview.py
+++ b/src/ui/widgets/preview/audio_preview.py
@@ -15,7 +15,6 @@ from PyQt6.QtWidgets import (
     QGroupBox, QSplitter, QVBoxLayout, QWidget
 )
 
-from src.workflow.port import DataType
 from src.ui.i18n import tr_
 from src.ui.styles import Styles
 from src.ui.widgets.audio_player import AudioPlayerWidget
@@ -36,7 +35,6 @@ class AudioPreviewWidget(BasePreviewWidget):
     显示音频的波形、频谱图，并提供播放控制。
     """
     
-    supported_types = [DataType.AUDIO]
     display_name = tr_("Audio preview")
     icon = "🎵"
     
@@ -106,7 +104,7 @@ class AudioPreviewWidget(BasePreviewWidget):
         
         # 验证数据类型
         if not hasattr(data, 'data') or not hasattr(data, 'sample_rate'):
-            logger.warning(f"无效的音频数据类型: {type(data)}")
+            logger.warning("Invalid audio data type: %s", type(data))
             return False
         
         try:
@@ -139,7 +137,7 @@ class AudioPreviewWidget(BasePreviewWidget):
             return True
             
         except Exception as e:
-            logger.error(f"设置音频数据失败: {e}")
+            logger.error("Failed to set audio data: %s", e)
             return False
     
     def clear(self):

--- a/src/ui/widgets/preview/base_preview.py
+++ b/src/ui/widgets/preview/base_preview.py
@@ -11,23 +11,20 @@ from typing import Any, List, Optional, Type
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import QWidget
 
-from src.workflow.port import DataType
 from src.ui.i18n import tr_
 logger = logging.getLogger(__name__)
 
 
 class BasePreviewWidget(QWidget):
     """
-    预览组件基类
-    
-    所有专用预览组件都应继承此类并实现 set_data 和 clear 方法。
+    Base class for all preview widgets.
+
+    All specialized preview widgets should inherit from this class and implement
+    `set_data` and `clear`.
     
     Signals:
-        data_changed: 当显示的数据发生变化时发射
+        data_changed: emitted when displayed data changes
     """
-    
-    # 类属性：该组件支持的数据类型列表
-    supported_types: List[DataType] = []
     
     # 组件显示名称
     display_name: str = tr_("Base preview")
@@ -45,58 +42,58 @@ class BasePreviewWidget(QWidget):
     
     @property
     def current_data(self) -> Any:
-        """获取当前显示的数据"""
+        """Return the currently displayed data object."""
         return self._current_data
     
     @property
     def data_info(self) -> str:
-        """获取数据信息字符串（用于显示在标题栏）"""
+        """Return a short info string shown in the header."""
         return self._data_info
     
     def set_data(self, data: Any) -> bool:
         """
-        设置要显示的数据
+        Set the data to be displayed.
         
         Args:
-            data: 要显示的数据对象
+            data: data object to display
             
         Returns:
-            是否成功设置数据
+            True if data was accepted and rendered
         
         Note:
-            子类必须实现此方法
+            Subclasses must implement this method.
         """
         raise NotImplementedError(tr_("Subclasses must implement set_data()"))
     
     def clear(self):
         """
-        清除当前显示
+        Clear current view.
         
         Note:
-            子类必须实现此方法
+            Subclasses must implement this method.
         """
         raise NotImplementedError(tr_("Subclasses must implement clear()"))
     
     @classmethod
     def can_display(cls, data: Any) -> bool:
         """
-        检查该组件是否能显示给定的数据
+        Return whether this widget can display the given data object.
         
         Args:
-            data: 要检查的数据对象
+            data: data object to check
             
         Returns:
-            是否可以显示该数据
+            True if this widget can display the data
         """
-        # 默认实现：子类可以覆盖以提供更精确的检查
+        # Default implementation: subclasses may override for better checks.
         return False
     
     def _update_data_info(self, info: str):
-        """更新数据信息"""
+        """Update the header info string."""
         self._data_info = info
 
 
-# 预览组件注册表
+# Preview widget registry.
 _preview_registry: List[Type[BasePreviewWidget]] = []
 
 
@@ -110,7 +107,7 @@ def register_preview(widget_class: Type[BasePreviewWidget]) -> Type[BasePreviewW
             ...
     """
     _preview_registry.append(widget_class)
-    logger.debug(f"注册预览组件: {widget_class.__name__}")
+    logger.debug("Registered preview widget: %s", widget_class.__name__)
     return widget_class
 
 

--- a/src/ui/widgets/preview/feature_1d_preview.py
+++ b/src/ui/widgets/preview/feature_1d_preview.py
@@ -15,7 +15,6 @@ from PyQt6.QtWidgets import (
     QGroupBox, QLabel, QVBoxLayout, QWidget
 )
 
-from src.workflow.port import DataType
 from src.ui.i18n import tr_
 from src.ui.styles import Styles
 
@@ -41,7 +40,6 @@ class Feature1DPreviewWidget(BasePreviewWidget):
     显示一维特征数据的线图。
     """
     
-    supported_types = [DataType.FEATURE_1D, DataType.FEATURE]
     display_name = tr_("1D feature")
     icon = "📈"
     

--- a/src/ui/widgets/preview/feature_2d_preview.py
+++ b/src/ui/widgets/preview/feature_2d_preview.py
@@ -15,7 +15,6 @@ from PyQt6.QtWidgets import (
     QGroupBox, QHBoxLayout, QLabel, QSplitter, QVBoxLayout, QWidget
 )
 
-from src.workflow.port import DataType
 from src.ui.i18n import tr_
 from src.ui.styles import Styles
 
@@ -41,7 +40,6 @@ class Feature2DPreviewWidget(BasePreviewWidget):
     显示二维特征数据的热力图和边际分布。
     """
     
-    supported_types = [DataType.FEATURE_2D, DataType.FEATURE]
     display_name = tr_("2D feature")
     icon = "🗺️"
     

--- a/src/ui/widgets/preview/label_preview.py
+++ b/src/ui/widgets/preview/label_preview.py
@@ -17,7 +17,6 @@ from PyQt6.QtWidgets import (
     QSplitter, QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget
 )
 
-from src.workflow.port import DataType
 from src.ui.i18n import tr_
 from src.ui.styles import Styles
 
@@ -42,7 +41,6 @@ class LabelPreviewWidget(BasePreviewWidget):
     显示标签数据的表格视图、统计信息和分布图。
     """
     
-    supported_types = [DataType.LABEL]
     display_name = tr_("Label preview")
     icon = "🏷️"
     

--- a/src/ui/widgets/preview/metrics_preview.py
+++ b/src/ui/widgets/preview/metrics_preview.py
@@ -15,7 +15,6 @@ from PyQt6.QtWidgets import (
     QGroupBox, QHBoxLayout, QLabel, QSplitter, QVBoxLayout, QWidget
 )
 
-from src.workflow.port import DataType
 from src.ui.i18n import tr_
 from src.ui.styles import Styles
 
@@ -40,7 +39,6 @@ class MetricsPreviewWidget(BasePreviewWidget):
     显示评估指标的柱状图和详细文本。
     """
     
-    supported_types = [DataType.METRICS]
     display_name = tr_("Metrics")
     icon = "📊"
     

--- a/src/ui/widgets/preview/model_preview.py
+++ b/src/ui/widgets/preview/model_preview.py
@@ -15,7 +15,6 @@ from PyQt6.QtWidgets import (
     QTextEdit, QVBoxLayout, QWidget
 )
 
-from src.workflow.port import DataType
 from src.ui.i18n import tr_
 from src.ui.styles import Styles
 
@@ -33,7 +32,6 @@ class ModelPreviewWidget(BasePreviewWidget):
     显示 Keras 模型的 summary 信息和参数统计。
     """
     
-    supported_types = [DataType.MODEL]
     display_name = tr_("Model preview")
     icon = "🧠"
     


### PR DESCRIPTION
## Summary
- Reduce UI-to-domain coupling by moving node double-click routing decisions into NavigationController (DTO-based).
- Extract GPU/memory detection and training-params derivation into UI-agnostic services.
- Remove cross-component access to private WorkflowView controls.

## Related Issue
Closes #20

## Test Plan
- [x] `python -m py_compile` on touched modules
- [x] Launch `python main.py` (smoke)
- [ ] Manual: double-click nodes (`save_model`, `label_file`, `loop`, `trainer`, `show_history`) and verify routing/messages