### PR TITLE
feat(workflow): rerun workflow from selected node

### DIFF
--- a/src/controllers/workflow_controller.py
+++ b/src/controllers/workflow_controller.py
@@ -135,6 +135,33 @@ class WorkflowController(QObject):
             self._event_bus.emit_status(tr_("Failed to start workflow"))
         
         return success
+
+    def run_from_node(self, node_id: str, *, validate: bool = True) -> bool:
+        """
+        Run the current workflow starting from a selected node.
+
+        Preserves valid upstream cached outputs and reruns only the selected node
+        together with its downstream nodes.
+        """
+        if not self._workflow:
+            self._event_bus.emit_status(tr_("No workflow to run"))
+            return False
+
+        if validate:
+            valid, errors = self.validate_workflow(self._workflow)
+            if not valid:
+                error_msg = tr_("Workflow validation failed:\n{errors}").format(
+                    errors="\n".join(errors)
+                )
+                self._event_bus.workflow_error.emit(error_msg)
+                return False
+
+        self._event_bus.emit_status(tr_("Starting workflow from selected node..."))
+        success = self._engine.execute_from(node_id)
+        if not success:
+            self._event_bus.emit_status(tr_("Failed to start workflow from selected node"))
+
+        return success
     
     def stop(self):
         """停止工作流执行"""

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -293,6 +293,7 @@ class MainWindow(QWidget):
         self._workflow_view.run_requested.connect(self._on_run_workflow)
         self._workflow_view.node_selected.connect(self._on_node_selected)
         self._workflow_view.node_double_clicked.connect(self._on_node_double_clicked)
+        self._workflow_view.run_from_node_requested.connect(self._on_run_from_node)
         
         # 预览视图信号
         self._preview_view.preview_requested.connect(self._on_preview_requested)
@@ -355,7 +356,7 @@ class MainWindow(QWidget):
         if self._workflow_view.get_running_tab_index() is None:
             self._workflow_view.set_running_tab_index(self._workflow_view.get_current_tab_index())
         self.training_started.emit()
-        self._workflow_view.reset_all_node_states()
+        self._reset_runtime_node_states_for_active_run()
         # Ensure workflow run controls are updated when a run starts.
         self._workflow_view.set_run_controls_state(
             run_enabled=False,
@@ -556,6 +557,59 @@ class MainWindow(QWidget):
         # Notify training controller using derived params (UI should not traverse nodes).
         # Only start training tracking after the workflow successfully starts.
         self._training_controller.start_training_for_workflow(workflow, default_epochs=20)
+
+    def _on_run_from_node(self, node_id: str):
+        """Handle partial workflow rerun starting from the selected node."""
+        if self._is_workflow_run_active():
+            running_idx = self._workflow_view.get_running_tab_index()
+            current_idx = self._workflow_view.get_current_tab_index()
+            if running_idx is not None and current_idx != running_idx:
+                self._event_bus.emit_status(
+                    tr_("A workflow is already running. Switching to the running tab.")
+                )
+                self._workflow_view.activate_running_tab()
+                return
+
+            self._event_bus.emit_status(tr_("A workflow is already running."))
+            return
+
+        workflow = self._workflow_view.get_workflow()
+        if not workflow:
+            QMessageBox.warning(self, tr_("Warning"), tr_("No runnable workflow."))
+            return
+
+        node = workflow.get_node(node_id)
+        if node is None:
+            QMessageBox.warning(self, tr_("Warning"), tr_("Selected node does not exist."))
+            return
+
+        self._workflow_view.set_running_tab_index(self._workflow_view.get_current_tab_index())
+        self._workflow_controller.set_workflow(workflow)
+
+        valid, errors = self._workflow_controller.validate_workflow(workflow)
+        if not valid:
+            QMessageBox.warning(
+                self,
+                tr_("Validation failed"),
+                tr_("Workflow validation failed:\n") + "\n".join(errors),
+            )
+            self._workflow_view.clear_running_tab()
+            return
+
+        success = self._workflow_controller.run_from_node(node_id, validate=False)
+        if not success:
+            self._workflow_view.clear_breakpoint_mode()
+            self._workflow_view.clear_running_tab()
+            self._workflow_view.set_run_controls_state(
+                run_enabled=True,
+                stop_enabled=False,
+                stop_text=tr_("⏹️ Stop"),
+            )
+            self._training_controller.finish_training(False, tr_("Startup failed"))
+            return
+
+        self._selected_node_id = node_id
+        self._training_controller.start_training_for_workflow(workflow, default_epochs=20)
     
     def _on_pause_training(self):
         """暂停训练"""
@@ -587,7 +641,7 @@ class MainWindow(QWidget):
         self.training_started.emit()
         
         # 重置所有节点的可视化状态
-        self._workflow_view.reset_all_node_states()
+        self._reset_runtime_node_states_for_active_run()
     
     def _on_engine_finished(self, result: ExecutionResult):
         """引擎执行完成"""
@@ -832,6 +886,16 @@ class MainWindow(QWidget):
                 "Click \"Run\" to execute the workflow first."
             ).format(name=node.display_name),
         )
+
+    def _reset_runtime_node_states_for_active_run(self):
+        """Reset only the nodes participating in the active run when possible."""
+        workflow = self._workflow_controller.workflow or self._workflow_view.get_workflow()
+        active_node_ids = self._workflow_controller.engine.get_active_run_node_ids()
+        if workflow and active_node_ids and len(active_node_ids) < len(workflow.nodes):
+            self._workflow_view.reset_node_states(sorted(active_node_ids))
+            return
+
+        self._workflow_view.reset_all_node_states()
     
     # ===== 兼容旧接口 =====
     

--- a/src/ui/node_editor/node_graph.py
+++ b/src/ui/node_editor/node_graph.py
@@ -395,6 +395,12 @@ class NodeGraphScene(BaseGraphScene):
         """重置所有节点的执行状态为 idle"""
         for node_item in self.node_items.values():
             node_item.set_execution_state('idle')
+
+    def reset_node_states(self, node_ids: List[str]):
+        """Reset the execution state of the specified nodes to idle."""
+        for node_id in node_ids:
+            if node_id in self.node_items:
+                self.node_items[node_id].set_execution_state('idle')
     
     def highlight_node(self, node_id: str):
         """高亮显示指定节点（居中并选中）"""
@@ -536,6 +542,7 @@ class NodeGraphWidget(QWidget):
     
     node_selected = pyqtSignal(str)
     node_double_clicked = pyqtSignal(str)
+    run_from_node_requested = pyqtSignal(str)
     connection_created = pyqtSignal(str, str, str, str)
     workflow_changed = pyqtSignal()
     
@@ -666,12 +673,26 @@ class NodeGraphWidget(QWidget):
             if isinstance(item, NodeItem):
                 return item.node.node_id
         return None
+
+    def get_selected_node_ids(self) -> List[str]:
+        """Get all selected node IDs."""
+        node_ids: List[str] = []
+        for item in self._scene.selectedItems():
+            if isinstance(item, NodeItem):
+                node_ids.append(item.node.node_id)
+        return node_ids
     
     def _show_context_menu(self, pos):
         """显示右键菜单"""
         menu = QMenu(self)
         
         # 注：新增节点统一从左侧「节点库」添加，避免右键菜单随节点数量膨胀。
+
+        selected_node_ids = self.get_selected_node_ids()
+
+        rerun_action = menu.addAction(tr_("Rerun from selected node"))
+        rerun_action.setEnabled(len(selected_node_ids) == 1 and self.workflow is not None)
+        rerun_action.triggered.connect(self._rerun_from_selected_node)
         
         # 重置选中节点连接
         reset_conn_action = menu.addAction(tr_("Reset selected node connections"))
@@ -682,6 +703,12 @@ class NodeGraphWidget(QWidget):
         delete_action.triggered.connect(self._delete_selected)
         
         menu.exec(self._view.mapToGlobal(pos))
+
+    def _rerun_from_selected_node(self):
+        """Emit a request to rerun the workflow from the selected node."""
+        node_id = self.get_selected_node_id()
+        if node_id:
+            self.run_from_node_requested.emit(node_id)
     
     def _delete_selected(self):
         """Delete selected items.
@@ -768,6 +795,10 @@ class NodeGraphWidget(QWidget):
     def reset_all_node_states(self):
         """重置所有节点的执行状态为 idle"""
         self._scene.reset_all_node_states()
+
+    def reset_node_states(self, node_ids: List[str]):
+        """Reset the execution state of the specified nodes to idle."""
+        self._scene.reset_node_states(node_ids)
     
     def highlight_node(self, node_id: str):
         """高亮显示指定节点（居中并选中）"""

--- a/src/ui/views/workflow_editor_widget.py
+++ b/src/ui/views/workflow_editor_widget.py
@@ -31,6 +31,7 @@ class WorkflowEditorWidget(QWidget):
     workflow_changed = pyqtSignal()
     node_selected = pyqtSignal(str)
     node_double_clicked = pyqtSignal(str)
+    run_from_node_requested = pyqtSignal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -73,6 +74,7 @@ class WorkflowEditorWidget(QWidget):
         self._node_palette.node_add_requested.connect(self._on_add_node_from_palette)
         self._node_graph.node_selected.connect(self._on_node_selected)
         self._node_graph.node_double_clicked.connect(self.node_double_clicked)
+        self._node_graph.run_from_node_requested.connect(self.run_from_node_requested)
         self._node_graph.workflow_changed.connect(self._on_workflow_changed)
         self._property_panel.parameter_changed.connect(self._on_parameter_changed)
 
@@ -93,6 +95,9 @@ class WorkflowEditorWidget(QWidget):
 
     def reset_all_node_states(self):
         self._node_graph.reset_all_node_states()
+
+    def reset_node_states(self, node_ids: list[str]):
+        self._node_graph.reset_node_states(node_ids)
 
     def highlight_node(self, node_id: str):
         self._node_graph.highlight_node(node_id)

--- a/src/ui/views/workflow_tabs_view.py
+++ b/src/ui/views/workflow_tabs_view.py
@@ -54,6 +54,7 @@ class WorkflowTabsView(QWidget):
     run_requested = pyqtSignal()
     node_selected = pyqtSignal(str)
     node_double_clicked = pyqtSignal(str)
+    run_from_node_requested = pyqtSignal(str)
     continue_requested = pyqtSignal()
 
     def __init__(self, parent=None):
@@ -192,6 +193,11 @@ class WorkflowTabsView(QWidget):
         editor = self._runtime_editor()
         if editor:
             editor.reset_all_node_states()
+
+    def reset_node_states(self, node_ids: list[str]):
+        editor = self._runtime_editor()
+        if editor:
+            editor.reset_node_states(node_ids)
 
     def update_node_state(self, node_id: str, state: str):
         editor = self._runtime_editor()
@@ -386,6 +392,7 @@ class WorkflowTabsView(QWidget):
         editor.workflow_changed.connect(self._on_editor_workflow_changed)
         editor.node_selected.connect(self.node_selected)
         editor.node_double_clicked.connect(self.node_double_clicked)
+        editor.run_from_node_requested.connect(self.run_from_node_requested)
 
         idx = self._tabs.addTab(editor, "")
         self._update_tab_title(idx)

--- a/src/ui/views/workflow_view.py
+++ b/src/ui/views/workflow_view.py
@@ -38,6 +38,7 @@ class WorkflowView(QWidget):
     run_requested = pyqtSignal()
     node_selected = pyqtSignal(str)
     node_double_clicked = pyqtSignal(str)
+    run_from_node_requested = pyqtSignal(str)
     continue_requested = pyqtSignal()
 
     def __init__(self, parent=None, *, show_toolbar: bool = True):
@@ -69,6 +70,7 @@ class WorkflowView(QWidget):
         self._editor.workflow_changed.connect(self._on_workflow_changed)
         self._editor.node_selected.connect(self.node_selected)
         self._editor.node_double_clicked.connect(self.node_double_clicked)
+        self._editor.run_from_node_requested.connect(self.run_from_node_requested)
 
         if self._toolbar is not None:
             self._toolbar.new_requested.connect(self._on_new_workflow)
@@ -95,6 +97,9 @@ class WorkflowView(QWidget):
 
     def reset_all_node_states(self):
         self._editor.reset_all_node_states()
+
+    def reset_node_states(self, node_ids: list[str]):
+        self._editor.reset_node_states(node_ids)
 
     def highlight_node(self, node_id: str):
         self._editor.highlight_node(node_id)

--- a/src/workflow/engine.py
+++ b/src/workflow/engine.py
@@ -89,6 +89,8 @@ class WorkflowEngine(QObject):
         
         # Worker thread
         self._worker: Optional[EngineWorker] = None
+        self._pending_execution_node_ids: Optional[Set[str]] = None
+        self._active_execution_node_ids: Optional[Set[str]] = None
     
     def set_workflow(self, workflow: Workflow):
         """Set workflow to execute"""
@@ -104,38 +106,16 @@ class WorkflowEngine(QObject):
         Returns:
             Whether execution started successfully
         """
-        if workflow:
-            self.workflow = workflow
-        
-        if not self.workflow:
-            self.workflow_error.emit(tr_("Workflow not set"))
-            return False
+        return self._start_execution(workflow=workflow)
 
-        # Prevent starting a new run while the previous worker thread is still finishing.
-        # A terminal state (COMPLETED/STOPPED/ERROR) can be observed before QThread fully exits.
-        if self._worker is not None and self._worker.isRunning():
-            self.workflow_error.emit(tr_("Workflow is already running"))
-            return False
-        
-        if self.state == EngineState.RUNNING:
-            self.workflow_error.emit(tr_("Workflow is already running"))
-            return False
-        
-        # Validate workflow
-        valid, errors = self.workflow.validate()
-        if not valid:
-            self.workflow_error.emit("\n".join(errors))
-            return False
-        
-        # Reset state
-        self._reset()
-        
-        # Create and start worker thread
-        self._worker = EngineWorker(self)
-        self._worker.finished.connect(self._on_worker_finished)
-        self._worker.start()
-        
-        return True
+    def execute_from(self, start_node_id: str, workflow: Workflow = None) -> bool:
+        """
+        Execute workflow starting from a specific node.
+
+        Preserves cached upstream outputs and only reruns the target node plus its
+        downstream nodes.
+        """
+        return self._start_execution(workflow=workflow, start_node_id=start_node_id)
     
     def execute_sync(self) -> ExecutionResult:
         """
@@ -144,26 +124,27 @@ class WorkflowEngine(QObject):
         Returns:
             Execution result
         """
-        if not self.workflow:
+        ok, error = self._prepare_execution()
+        if not ok:
             return ExecutionResult(
                 success=False,
-                message=tr_("Workflow not set"),
+                message=error or tr_("Workflow not set"),
                 execution_time=0,
                 node_results={}
             )
-        
-        # Validate workflow
-        valid, errors = self.workflow.validate()
-        if not valid:
+        return self._execute_pending_workflow()
+
+    def execute_from_sync(self, start_node_id: str, workflow: Workflow = None) -> ExecutionResult:
+        """Synchronously execute a workflow subset from the selected node."""
+        ok, error = self._prepare_execution(workflow=workflow, start_node_id=start_node_id)
+        if not ok:
             return ExecutionResult(
                 success=False,
-                message="\n".join(errors),
+                message=error or tr_("Workflow not set"),
                 execution_time=0,
                 node_results={}
             )
-        
-        self._reset()
-        return self._execute_workflow()
+        return self._execute_pending_workflow()
     
     def stop(self):
         """Stop execution"""
@@ -202,9 +183,15 @@ class WorkflowEngine(QObject):
     def get_current_breakpoint_node(self) -> Optional[str]:
         """Get current breakpoint node ID"""
         return self._current_breakpoint_node
+
+    def get_active_run_node_ids(self) -> Optional[Set[str]]:
+        """Get the node IDs scheduled for the current run."""
+        if self._active_execution_node_ids is None:
+            return None
+        return set(self._active_execution_node_ids)
     
-    def _reset(self):
-        """Reset engine state"""
+    def _reset(self, node_ids: Optional[Set[str]] = None):
+        """Reset engine state and optionally only a subset of nodes."""
         self._stop_requested = False
         self._pause_requested = False
         self._breakpoint_waiting = False
@@ -214,12 +201,138 @@ class WorkflowEngine(QObject):
         self._loop_data.clear()
         self.state = EngineState.IDLE
         
-        # Reset all nodes
+        # Reset nodes
         if self.workflow:
-            for node in self.workflow.nodes.values():
+            nodes_to_reset: List[BaseNode]
+            if node_ids is None:
+                nodes_to_reset = list(self.workflow.nodes.values())
+            else:
+                nodes_to_reset = [
+                    node for node_id, node in self.workflow.nodes.items()
+                    if node_id in node_ids
+                ]
+
+            for node in nodes_to_reset:
                 node.reset()
-    
-    def _execute_workflow(self) -> ExecutionResult:
+
+    def _start_execution(
+        self,
+        *,
+        workflow: Workflow = None,
+        start_node_id: Optional[str] = None,
+    ) -> bool:
+        ok, error = self._prepare_execution(workflow=workflow, start_node_id=start_node_id)
+        if not ok:
+            self.workflow_error.emit(error or tr_("Workflow not set"))
+            return False
+
+        self._worker = EngineWorker(self)
+        self._worker.finished.connect(self._on_worker_finished)
+        self._worker.start()
+        return True
+
+    def _prepare_execution(
+        self,
+        *,
+        workflow: Workflow = None,
+        start_node_id: Optional[str] = None,
+    ) -> tuple[bool, Optional[str]]:
+        if workflow:
+            self.workflow = workflow
+
+        if not self.workflow:
+            return False, tr_("Workflow not set")
+
+        # Prevent starting a new run while the previous worker thread is still finishing.
+        # A terminal state (COMPLETED/STOPPED/ERROR) can be observed before QThread fully exits.
+        if self._worker is not None and self._worker.isRunning():
+            return False, tr_("Workflow is already running")
+
+        if self.state == EngineState.RUNNING:
+            return False, tr_("Workflow is already running")
+
+        valid, errors = self.workflow.validate()
+        if not valid:
+            return False, "\n".join(errors)
+
+        execution_node_ids: Optional[Set[str]] = None
+        if start_node_id is not None:
+            execution_node_ids = self._resolve_execution_node_ids(start_node_id)
+            if execution_node_ids is None:
+                return False, tr_("Start node does not exist")
+
+            valid_cache, cache_error = self._validate_cached_inputs_for_subset(execution_node_ids)
+            if not valid_cache:
+                return False, cache_error
+
+        self._pending_execution_node_ids = execution_node_ids
+        self._reset(node_ids=execution_node_ids)
+        return True, None
+
+    def _execute_pending_workflow(self) -> ExecutionResult:
+        self._active_execution_node_ids = (
+            set(self._pending_execution_node_ids)
+            if self._pending_execution_node_ids is not None
+            else None
+        )
+        self._pending_execution_node_ids = None
+        try:
+            return self._execute_workflow(target_node_ids=self._active_execution_node_ids)
+        finally:
+            self._active_execution_node_ids = None
+
+    def _resolve_execution_node_ids(self, start_node_id: str) -> Optional[Set[str]]:
+        """Resolve the selected node plus all downstream nodes."""
+        if not self.workflow:
+            return None
+        if not self.workflow.get_node(start_node_id):
+            return None
+
+        node_ids = set(self.workflow.get_downstream_nodes(start_node_id))
+        node_ids.add(start_node_id)
+        return node_ids
+
+    def _validate_cached_inputs_for_subset(
+        self,
+        target_node_ids: Set[str],
+    ) -> tuple[bool, Optional[str]]:
+        """Ensure required inputs from preserved upstream branches still have cached data."""
+        if not self.workflow:
+            return False, tr_("Workflow not set")
+
+        for node_id in target_node_ids:
+            node = self.workflow.get_node(node_id)
+            if node is None:
+                continue
+
+            for conn in self.workflow.get_incoming_connections(node_id):
+                if conn.source_node_id in target_node_ids:
+                    continue
+                if conn.target_port not in node.inputs:
+                    continue
+
+                input_port = node.inputs[conn.target_port]
+                if not input_port.required or input_port.default_value is not None:
+                    continue
+
+                source_node = self.workflow.get_node(conn.source_node_id)
+                if source_node is None or conn.source_port not in source_node.outputs:
+                    return False, tr_(
+                        "Cannot rerun from '{node}'. Upstream connection data is unavailable."
+                    ).format(node=node.display_name)
+
+                source_data = source_node.outputs[conn.source_port].data
+                if source_data is None:
+                    return False, tr_(
+                        "Cannot rerun from '{node}'. Required cached output from upstream node '{upstream}' is missing."
+                    ).format(
+                        node=node.display_name,
+                        upstream=source_node.display_name,
+                    )
+
+        return True, None
+
+    def _execute_workflow(self, target_node_ids: Optional[Set[str]] = None) -> ExecutionResult:
         """
         Core workflow execution logic
         
@@ -235,11 +348,27 @@ class WorkflowEngine(QObject):
             
             # Get execution order
             execution_order, has_cycle = self.workflow.get_execution_order()
+            if target_node_ids is not None:
+                execution_order = [
+                    node_id for node_id in execution_order
+                    if node_id in target_node_ids
+                ]
             
             if has_cycle:
                 # Has cycle, use special handling
                 # Currently simple handling: ignore cycle, execute in topological order
                 logger.warning("Detected cyclic dependency, will try to execute in topological order")
+
+            if not execution_order:
+                self.state = EngineState.ERROR
+                result = ExecutionResult(
+                    success=False,
+                    message=tr_("No runnable nodes found"),
+                    execution_time=time.time() - start_time,
+                    node_results=node_results
+                )
+                self.workflow_finished.emit(result)
+                return result
             
             total_nodes = len(execution_order)
             
@@ -490,5 +619,5 @@ class EngineWorker(QThread):
     
     def run(self):
         """Thread execution"""
-        self.engine._execute_workflow()
+        self.engine._execute_pending_workflow()
 

--- a/src/workflow/node_base.py
+++ b/src/workflow/node_base.py
@@ -292,6 +292,11 @@ class BaseNode(ABC):
             port.clear()
         for port in self.outputs.values():
             port.clear()
+        self.on_reset()
+
+    def on_reset(self):
+        """Hook for subclasses to clear internal runtime state."""
+        pass
     
     def report_progress(self, progress: float, message: str = "", data: Dict = None):
         """

--- a/src/workflow/nodes/control.py
+++ b/src/workflow/nodes/control.py
@@ -104,6 +104,10 @@ class LoopNode(BaseNode):
         self._current_index = 0
         self._data_list = None
 
+    def on_reset(self):
+        """Clear loop runtime state before a new execution."""
+        self.reset_loop()
+
 
 @register_node
 class SplitNode(BaseNode):


### PR DESCRIPTION
## Summary
- add partial workflow execution so a run can restart from a selected node while preserving cached upstream outputs
- add cache validation and node reset hooks so partial reruns avoid stale control-node runtime state
- expose a node context menu action and UI/controller wiring for rerunning the selected node and its downstream graph

## Related Issue
Closes #54

## Test Plan
- [x] `python -m compileall src/workflow/engine.py src/workflow/node_base.py src/workflow/nodes/control.py src/controllers/workflow_controller.py src/ui/node_editor/node_graph.py src/ui/views/workflow_editor_widget.py src/ui/views/workflow_view.py src/ui/views/workflow_tabs_view.py src/ui/main_window.py`
- [x] In-memory smoke test covering full run, rerun from a middle node, missing upstream cache rejection, and `LoopNode` reset behavior
- [ ] Manual GUI verification of the new context menu flow