### PR TITLE
feat(editor): center double-click add placement

### DIFF
--- a/src/ui/model_editor/model_graph_widget.py
+++ b/src/ui/model_editor/model_graph_widget.py
@@ -437,6 +437,12 @@ class ModelGraphWidget(QWidget):
         self._scene.add_layer_item(layer)
         self.graph_changed.emit()
         return layer.layer_id
+
+    def get_visible_viewport_center(self) -> tuple[float, float]:
+        """获取当前可视区域中心点（场景坐标）"""
+        viewport_center = self._view.viewport().rect().center()
+        scene_pos = self._view.mapToScene(viewport_center)
+        return scene_pos.x(), scene_pos.y()
     
     def remove_layer(self, layer_id: str):
         """移除层"""

--- a/src/ui/node_editor/node_graph.py
+++ b/src/ui/node_editor/node_graph.py
@@ -623,6 +623,12 @@ class NodeGraphWidget(QWidget):
         
         self.workflow_changed.emit()
         return node.node_id
+
+    def get_visible_viewport_center(self) -> Tuple[float, float]:
+        """获取当前可视区域中心点（场景坐标）"""
+        viewport_center = self._view.viewport().rect().center()
+        scene_pos = self._view.mapToScene(viewport_center)
+        return scene_pos.x(), scene_pos.y()
     
     def remove_node(self, node_id: str):
         """移除节点"""

--- a/src/ui/views/model_builder_view.py
+++ b/src/ui/views/model_builder_view.py
@@ -257,7 +257,10 @@ class ModelBuilderView(QWidget):
     
     def _on_add_layer(self, layer_type: str):
         """添加层"""
-        self._graph_widget.add_layer(layer_type, (100, 100))
+        self._graph_widget.add_layer(
+            layer_type,
+            self._graph_widget.get_visible_viewport_center(),
+        )
     
     def _on_layer_selected(self, layer_id: str):
         """层选中"""

--- a/src/ui/views/workflow_editor_widget.py
+++ b/src/ui/views/workflow_editor_widget.py
@@ -108,7 +108,10 @@ class WorkflowEditorWidget(QWidget):
     # ===== Internal event handlers =====
 
     def _on_add_node_from_palette(self, node_type: str):
-        self._node_graph.add_node(node_type, (100, 100))
+        self._node_graph.add_node(
+            node_type,
+            self._node_graph.get_visible_viewport_center(),
+        )
 
     def _on_node_selected(self, node_id: str):
         workflow = self._node_graph.get_workflow()

--- a/tests/test_double_click_center_placement.py
+++ b/tests/test_double_click_center_placement.py
@@ -1,0 +1,68 @@
+import os
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication
+
+from src.model_builder import get_all_layer_types
+from src.ui.views.model_builder_view import ModelBuilderView
+from src.ui.views.workflow_editor_widget import WorkflowEditorWidget
+from src.workflow import Workflow
+from src.workflow.node_base import get_all_node_types
+
+
+class DoubleClickCenterPlacementTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_workflow_double_click_add_uses_visible_viewport_center(self):
+        widget = WorkflowEditorWidget()
+        self.addCleanup(widget.close)
+        widget.resize(900, 600)
+        widget.show()
+
+        workflow = Workflow("test_workflow")
+        widget.set_workflow(workflow)
+
+        node_graph = widget._node_graph
+        node_graph._scene.setSceneRect(-2000, -2000, 4000, 4000)
+        node_graph._view.scale(1.5, 1.5)
+        node_graph._view.centerOn(420, 260)
+        self.app.processEvents()
+
+        expected_center = node_graph._view.mapToScene(
+            node_graph._view.viewport().rect().center()
+        )
+
+        widget._on_add_node_from_palette(get_all_node_types()[0])
+
+        self.assertEqual(len(workflow.nodes), 1)
+        node = next(iter(workflow.nodes.values()))
+        self.assertAlmostEqual(node.position[0], expected_center.x(), delta=2.0)
+        self.assertAlmostEqual(node.position[1], expected_center.y(), delta=2.0)
+
+    def test_model_double_click_add_uses_visible_viewport_center(self):
+        widget = ModelBuilderView()
+        self.addCleanup(widget.close)
+        widget.resize(900, 600)
+        widget.show()
+
+        graph_widget = widget._graph_widget
+        graph_widget._scene.setSceneRect(-2000, -2000, 4000, 4000)
+        graph_widget._view.scale(1.25, 1.25)
+        graph_widget._view.centerOn(360, 180)
+        self.app.processEvents()
+
+        expected_center = graph_widget._view.mapToScene(
+            graph_widget._view.viewport().rect().center()
+        )
+
+        widget._on_add_layer(get_all_layer_types()[0])
+
+        self.assertIsNotNone(widget.get_model_graph())
+        self.assertEqual(len(widget.get_model_graph().layers), 1)
+        layer = next(iter(widget.get_model_graph().layers.values()))
+        self.assertAlmostEqual(layer.position[0], expected_center.x(), delta=2.0)
+        self.assertAlmostEqual(layer.position[1], expected_center.y(), delta=2.0)


### PR DESCRIPTION
## Summary
- Center workflow palette double-click additions in the current visible viewport.
- Center model palette double-click additions in the current visible viewport.
- Add regression tests for viewport-centered double-click placement.

## Related Issue
Closes #57

## Test Plan
- [x] `python -m unittest tests.test_double_click_center_placement -v`
- [x] Manual UI verification after pan/zoom on both editors