### PR TITLE
feat(ui): add company homepage link to about dialog

### DIFF
--- a/src/ui/dialogs/about_dialog.py
+++ b/src/ui/dialogs/about_dialog.py
@@ -2,14 +2,19 @@
 About Dialog
 """
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QFont, QPixmap
+from PyQt6.QtCore import Qt, QUrl
+from PyQt6.QtGui import QDesktopServices, QFont, QPixmap
 from PyQt6.QtWidgets import (
     QDialog, QFrame, QHBoxLayout, QLabel,
     QPushButton, QVBoxLayout
 )
 
 from src.ui.i18n import tr_
+
+COMPANY_HOMEPAGE_URL = "http://www.suzhoudongyuan.com/"
+COMPANY_HOMEPAGE_LABEL = "公司主页："
+
+
 class AboutDialog(QDialog):
     """关于对话框"""
     
@@ -73,6 +78,22 @@ class AboutDialog(QDialog):
         tech_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         tech_label.setStyleSheet("color: #a6adc8; font-size: 11px;")
         layout.addWidget(tech_label)
+
+        homepage_label = QLabel(
+            f'<a href="{COMPANY_HOMEPAGE_URL}">'
+            f"{COMPANY_HOMEPAGE_LABEL}{COMPANY_HOMEPAGE_URL}"
+            "</a>"
+        )
+        homepage_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        homepage_label.setTextFormat(Qt.TextFormat.RichText)
+        homepage_label.setTextInteractionFlags(
+            Qt.TextInteractionFlag.LinksAccessibleByMouse
+            | Qt.TextInteractionFlag.LinksAccessibleByKeyboard
+        )
+        homepage_label.setOpenExternalLinks(False)
+        homepage_label.setStyleSheet("color: #89b4fa; font-size: 11px;")
+        homepage_label.linkActivated.connect(self._open_company_homepage)
+        layout.addWidget(homepage_label)
         
         layout.addStretch()
         
@@ -94,6 +115,9 @@ class AboutDialog(QDialog):
         layout.addLayout(btn_layout)
         
         self._apply_styles()
+
+    def _open_company_homepage(self, _link):
+        QDesktopServices.openUrl(QUrl(COMPANY_HOMEPAGE_URL))
     
     def _apply_styles(self):
         """应用样式"""

--- a/tests/test_about_dialog.py
+++ b/tests/test_about_dialog.py
@@ -1,0 +1,37 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication, QLabel
+
+from src.ui.dialogs.about_dialog import (
+    COMPANY_HOMEPAGE_LABEL,
+    COMPANY_HOMEPAGE_URL,
+    AboutDialog,
+)
+
+
+def test_about_dialog_homepage_link_opens_default_browser(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    dialog = AboutDialog()
+
+    opened_urls = []
+    monkeypatch.setattr(
+        "src.ui.dialogs.about_dialog.QDesktopServices.openUrl",
+        lambda url: opened_urls.append(url),
+    )
+
+    labels = dialog.findChildren(QLabel)
+    homepage_label = next(
+        label for label in labels if COMPANY_HOMEPAGE_LABEL in label.text()
+    )
+
+    assert COMPANY_HOMEPAGE_URL in homepage_label.text()
+
+    homepage_label.linkActivated.emit(COMPANY_HOMEPAGE_URL)
+
+    assert len(opened_urls) == 1
+    assert opened_urls[0].toString() == COMPANY_HOMEPAGE_URL
+
+    dialog.close()
+    app.processEvents()


### PR DESCRIPTION
## Summary
- Added a company homepage link to the Help > About dialog.
- Opens the company homepage through the system default browser when clicked.
- Added a focused PyQt test for the About dialog link behavior.

## Related Issue
Closes #73

## Test Plan
- [x] python -m pytest tests/test_app_icon_paths.py tests/test_about_dialog.py