### PR TITLE
feat(ui): add custom title bar navigation

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,7 @@ Main Application Class
 
 from collections.abc import Callable
 
-from PySide6.QtCore import Qt, QSize
+from PySide6.QtCore import QRect, Qt, QSize
 from PySide6.QtGui import QAction, QIcon, QKeySequence
 from PySide6.QtWidgets import (
     QFileDialog, QMainWindow, QMenu, QMenuBar,
@@ -17,6 +17,7 @@ from src.ui.dialogs.settings_dialog import SettingsDialog
 from src.ui.i18n import tr_
 from src.ui.main_window import MainWindow
 from src.ui.startup_splash import get_app_icon_path
+from src.ui.title_bar import AppTitleBar
 from src.utils.restart_manager import RestartManager
 from src.utils.config import config
 
@@ -48,6 +49,8 @@ class AudioTrainingApp(QMainWindow):
         self._restart_manager: RestartManager | None = None
         self._restart_in_progress = False
         self._startup_progress = startup_progress
+        self._custom_is_maximized = False
+        self._normal_geometry = QRect()
         self._init_ui()
         self._report_startup_progress(84, "Main window created...")
         self._init_menubar()
@@ -66,26 +69,43 @@ class AudioTrainingApp(QMainWindow):
     def _init_ui(self):
         """初始化用户界面"""
         self.setWindowTitle(tr_("AI Acoustic Signal Training Platform"))
+        self.setWindowFlag(Qt.WindowType.FramelessWindowHint, True)
         self.setMinimumSize(1280, 800)
         icon_path = get_app_icon_path()
         if icon_path.exists():
             self.setWindowIcon(QIcon(str(icon_path)))
         
-        # 设置主窗口内容
+        root_widget = QWidget(self)
+        self._root_layout = QVBoxLayout(root_widget)
+        self._root_layout.setContentsMargins(0, 0, 0, 0)
+        self._root_layout.setSpacing(0)
+
+        self.title_bar = AppTitleBar(self)
+        self.title_bar.view_changed.connect(self._switch_view)
+        self.title_bar.settings_requested.connect(self._show_settings)
+        self.title_bar.minimize_requested.connect(self.showMinimized)
+        self.title_bar.maximize_restore_requested.connect(self._toggle_maximized)
+        self.title_bar.close_requested.connect(self.close)
+        self._root_layout.addWidget(self.title_bar)
+
         self.main_window = MainWindow(self, startup_progress=self._startup_progress)
-        self.setCentralWidget(self.main_window)
+        self.main_window.view_changed.connect(self.title_bar.set_current_view)
+        self._root_layout.addWidget(self.main_window)
+        self.setCentralWidget(root_widget)
         
         # 居中显示
         self._center_window()
     
     def _init_menubar(self):
         """初始化菜单栏"""
-        menubar = self.menuBar()
+        menubar = QMenuBar(self)
+        self._root_layout.insertWidget(1, menubar)
         menubar.setStyleSheet("""
             QMenuBar {
                 background-color: #181825;
                 color: #cdd6f4;
                 padding: 4px;
+                border-bottom: 1px solid #313244;
             }
             QMenuBar::item {
                 padding: 6px 12px;
@@ -152,13 +172,10 @@ class AudioTrainingApp(QMainWindow):
         self.action_exit.triggered.connect(self.close)
         file_menu.addAction(self.action_exit)
         
-        # === 编辑菜单 ===
-        edit_menu = menubar.addMenu(tr_("Edit(&E)"))
-        
         self.action_settings = QAction(tr_("Settings..."), self)
         self.action_settings.setShortcut(QKeySequence("Ctrl+,"))
         self.action_settings.triggered.connect(self._show_settings)
-        edit_menu.addAction(self.action_settings)
+        self.addAction(self.action_settings)
         
         # === 视图菜单 ===
         view_menu = menubar.addMenu(tr_("View(&V)"))
@@ -452,16 +469,26 @@ class AudioTrainingApp(QMainWindow):
     
     def _switch_view(self, index: int):
         """切换视图"""
-        self.main_window._view_stack.setCurrentIndex(index)
-        # 更新对应的视图按钮状态
-        buttons = [
-            self.main_window._workflow_btn,
-            self.main_window._model_btn,
-            self.main_window._preview_btn,
-            self.main_window._training_btn
-        ]
-        if 0 <= index < len(buttons):
-            buttons[index].setChecked(True)
+        self.main_window.switch_view(index)
+        self.title_bar.set_current_view(index)
+
+    def _toggle_maximized(self):
+        """Toggle maximized state for the frameless window."""
+        is_maximized = (
+            self._custom_is_maximized
+            or self.isMaximized()
+            or bool(self.windowState() & Qt.WindowState.WindowMaximized)
+        )
+        if is_maximized:
+            self.showNormal()
+            if self._normal_geometry.isValid():
+                self.setGeometry(self._normal_geometry)
+            self._custom_is_maximized = False
+        else:
+            if not self.isMaximized():
+                self._normal_geometry = self.geometry()
+            self.showMaximized()
+            self._custom_is_maximized = True
     
     # === 工作流操作 ===
     

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -11,10 +11,9 @@ from collections.abc import Callable
 from typing import Optional
 
 from PySide6.QtCore import Qt, Signal, QTimer
-from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (
-    QButtonGroup, QFrame, QHBoxLayout, QLabel, QMessageBox,
-    QPushButton, QStackedWidget, QToolBar, QVBoxLayout, QWidget
+    QFrame, QHBoxLayout, QLabel, QMessageBox,
+    QStackedWidget, QVBoxLayout, QWidget
 )
 
 from src.controllers.navigation_controller import NavigationController
@@ -37,37 +36,6 @@ from src.workflow.workflow import Workflow
 logger = logging.getLogger(__name__)
 
 
-class ViewButton(QPushButton):
-    """View switch button."""
-    
-    def __init__(self, text: str, icon: str = "", parent=None):
-        super().__init__(f"{icon} {text}" if icon else text, parent)
-        self.setCheckable(True)
-        self.setMinimumWidth(100)
-        self._update_style()
-    
-    def _update_style(self):
-        self.setStyleSheet(f"""
-            QPushButton {{
-                background: transparent;
-                border: none;
-                border-radius: 6px;
-                padding: 8px 16px;
-                color: {Styles.COLORS['subtext1']};
-                font-size: 13px;
-            }}
-            QPushButton:hover {{
-                background: {Styles.COLORS['surface0']};
-                color: {Styles.COLORS['text']};
-            }}
-            QPushButton:checked {{
-                background: {Styles.COLORS['surface1']};
-                color: {Styles.COLORS['blue']};
-                font-weight: bold;
-            }}
-        """)
-
-
 class MainWindow(QWidget):
     """
     Main window widget.
@@ -84,6 +52,7 @@ class MainWindow(QWidget):
     training_started = Signal()
     training_stopped = Signal()
     training_completed = Signal(dict)
+    view_changed = Signal(int)
     
     def __init__(
         self,
@@ -137,9 +106,6 @@ class MainWindow(QWidget):
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(0)
         
-        # 顶部视图切换栏
-        self._create_view_switcher(main_layout)
-        
         # 主视图堆栈
         self._view_stack = QStackedWidget()
         main_layout.addWidget(self._view_stack)
@@ -164,62 +130,6 @@ class MainWindow(QWidget):
         
         # 状态栏
         self._create_status_bar(main_layout)
-    
-    def _create_view_switcher(self, layout):
-        """创建视图切换栏"""
-        switcher_frame = QFrame()
-        switcher_frame.setFixedHeight(50)
-        switcher_frame.setStyleSheet(f"""
-            QFrame {{
-                background: {Styles.COLORS['mantle']};
-                border-bottom: 1px solid {Styles.COLORS['surface0']};
-            }}
-        """)
-        
-        switcher_layout = QHBoxLayout(switcher_frame)
-        switcher_layout.setContentsMargins(12, 6, 12, 6)
-        switcher_layout.setSpacing(4)
-        
-        # Logo/标题
-        title = QLabel(tr_("🎵 AI Acoustic Training Platform"))
-        title.setStyleSheet(f"""
-            font-size: 15px;
-            font-weight: bold;
-            color: {Styles.COLORS['text']};
-            padding-right: 20px;
-        """)
-        switcher_layout.addWidget(title)
-        
-        # 分隔线
-        separator = QFrame()
-        separator.setFrameShape(QFrame.Shape.VLine)
-        separator.setStyleSheet(f"background: {Styles.COLORS['surface1']};")
-        separator.setFixedWidth(1)
-        switcher_layout.addWidget(separator)
-        
-        switcher_layout.addSpacing(12)
-        
-        # 视图按钮组
-        self._view_buttons = QButtonGroup(self)
-        self._view_buttons.setExclusive(True)
-        
-        self._workflow_btn = ViewButton(tr_("Workflow"), "🔧")
-        self._model_btn = ViewButton(tr_("Model"), "📐")
-        self._preview_btn = ViewButton(tr_("Preview"), "📊")
-        self._training_btn = ViewButton(tr_("Training"), "🏋️")
-        
-        self._workflow_btn.setChecked(True)
-        
-        for i, btn in enumerate([self._workflow_btn, self._model_btn, self._preview_btn, self._training_btn]):
-            self._view_buttons.addButton(btn, i)
-            switcher_layout.addWidget(btn)
-        
-        switcher_layout.addStretch()
-        
-        layout.addWidget(switcher_frame)
-        
-        # 连接视图切换
-        self._view_buttons.idClicked.connect(self._on_view_changed)
     
     def _create_status_bar(self, layout):
         """创建状态栏"""
@@ -362,9 +272,7 @@ class MainWindow(QWidget):
     def _on_controller_view_changed(self, view_index: int):
         """控制器请求视图切换"""
         self._view_stack.setCurrentIndex(view_index)
-        buttons = [self._workflow_btn, self._model_btn, self._preview_btn, self._training_btn]
-        if 0 <= view_index < len(buttons):
-            buttons[view_index].setChecked(True)
+        self.view_changed.emit(view_index)
     
     def _on_preview_updated(self, node_id: str, node_name: str, outputs: dict):
         """预览数据更新"""
@@ -458,6 +366,7 @@ class MainWindow(QWidget):
     def _on_view_changed(self, index: int):
         """视图切换"""
         self._view_stack.setCurrentIndex(index)
+        self.view_changed.emit(index)
         
         # 同步导航控制器状态，确保双击节点切换视图时状态一致
         self._navigation_controller.sync_current_view(index)
@@ -475,6 +384,10 @@ class MainWindow(QWidget):
         # 如果切换到预览视图，尝试更新当前选中节点的预览
         if index == 2 and self._selected_node_id:  # 索引2是预览视图
             self._update_preview(self._selected_node_id)
+
+    def switch_view(self, index: int):
+        """Switch to one of the primary application views."""
+        self._on_view_changed(index)
     
     def _on_workflow_changed(self):
         """工作流变化"""

--- a/src/ui/title_bar.py
+++ b/src/ui/title_bar.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+"""Custom frameless application title bar."""
+
+from PySide6.QtCore import QPoint, Qt, Signal
+from PySide6.QtGui import QColor, QLinearGradient, QPainter, QPen
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QWidget,
+)
+
+from src.ui.styles import Styles
+
+
+class AppSignalIcon(QWidget):
+    """Small rounded icon with a signal waveform motif."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setFixedSize(24, 24)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        rect = self.rect().adjusted(1, 1, -1, -1)
+        gradient = QLinearGradient(rect.topLeft(), rect.bottomRight())
+        gradient.setColorAt(0.0, QColor("#6d5dfc"))
+        gradient.setColorAt(0.55, QColor("#3f8cff"))
+        gradient.setColorAt(1.0, QColor("#cba6f7"))
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(gradient)
+        painter.drawRoundedRect(rect, 6, 6)
+
+        pen = QPen(QColor("#eef4ff"), 1.4)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+        painter.setPen(pen)
+
+        center_y = rect.center().y()
+        x_values = [6, 9, 12, 15, 18]
+        heights = [5, 10, 14, 9, 6]
+        for x, height in zip(x_values, heights):
+            painter.drawLine(x, center_y - height // 2, x, center_y + height // 2)
+
+        painter.end()
+
+
+class TitleNavButton(QPushButton):
+    """Top-level navigation tab used in the custom title bar."""
+
+    def __init__(self, text: str, object_name: str, parent=None):
+        super().__init__(text, parent)
+        self.setObjectName(object_name)
+        self.setCheckable(True)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setFixedHeight(38)
+        self.setMinimumWidth(78)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setStyleSheet(f"""
+            QPushButton {{
+                background: transparent;
+                border: none;
+                border-bottom: 2px solid transparent;
+                color: {Styles.COLORS['subtext1']};
+                font-size: 14px;
+                font-weight: 500;
+                padding: 8px 18px 7px 18px;
+            }}
+            QPushButton:hover {{
+                background: rgba(69, 71, 90, 0.45);
+                color: {Styles.COLORS['text']};
+            }}
+            QPushButton:checked {{
+                background: rgba(49, 50, 68, 0.88);
+                border-bottom: 2px solid {Styles.COLORS['blue']};
+                color: #f4f7ff;
+                font-weight: 600;
+            }}
+        """)
+
+
+class WindowControlButton(QPushButton):
+    """Small caption button for a frameless window."""
+
+    def __init__(self, text: str, object_name: str, parent=None, *, danger: bool = False):
+        super().__init__(text, parent)
+        self.setObjectName(object_name)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setFixedSize(36, 30)
+        hover = "rgba(243, 139, 168, 0.85)" if danger else "rgba(88, 91, 112, 0.55)"
+        active = Styles.COLORS["red"] if danger else "rgba(108, 112, 134, 0.7)"
+        self.setStyleSheet(f"""
+            QPushButton {{
+                background: transparent;
+                border: none;
+                color: {Styles.COLORS['subtext1']};
+                font-size: 13px;
+                font-weight: 400;
+            }}
+            QPushButton:hover {{
+                background: {hover};
+                color: #ffffff;
+            }}
+            QPushButton:pressed {{
+                background: {active};
+            }}
+        """)
+
+
+class AppTitleBar(QFrame):
+    """Compact custom title bar with app branding, navigation and window controls."""
+
+    view_changed = Signal(int)
+    settings_requested = Signal()
+    minimize_requested = Signal()
+    maximize_restore_requested = Signal()
+    close_requested = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("appTitleBar")
+        self.setFixedHeight(46)
+        self._drag_position: QPoint | None = None
+        self._setup_ui()
+
+    def set_current_view(self, index: int) -> None:
+        button = self._nav_group.button(index)
+        if button is not None:
+            button.setChecked(True)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            window = self.window()
+            self._drag_position = (
+                event.globalPosition().toPoint() - window.frameGeometry().topLeft()
+            )
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if (
+            event.buttons() & Qt.MouseButton.LeftButton
+            and self._drag_position is not None
+            and not self.window().isMaximized()
+        ):
+            self.window().move(event.globalPosition().toPoint() - self._drag_position)
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        self._drag_position = None
+        super().mouseReleaseEvent(event)
+
+    def mouseDoubleClickEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.maximize_restore_requested.emit()
+            event.accept()
+            return
+        super().mouseDoubleClickEvent(event)
+
+    def _setup_ui(self) -> None:
+        self.setStyleSheet(f"""
+            QFrame#appTitleBar {{
+                background: qlineargradient(
+                    x1: 0, y1: 0, x2: 1, y2: 0,
+                    stop: 0 #0b1020,
+                    stop: 0.48 {Styles.COLORS['mantle']},
+                    stop: 1 #21172f
+                );
+                border-bottom: 1px solid rgba(88, 91, 112, 0.55);
+            }}
+        """)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(16, 0, 8, 0)
+        layout.setSpacing(10)
+
+        icon = AppSignalIcon(self)
+        layout.addWidget(icon, 0, Qt.AlignmentFlag.AlignVCenter)
+
+        title = QLabel("AI 声学信号训练平台", self)
+        title.setObjectName("appTitleLabel")
+        title.setStyleSheet("""
+            QLabel#appTitleLabel {
+                color: #f4f7ff;
+                font-size: 16px;
+                font-weight: 600;
+                letter-spacing: 0.2px;
+            }
+        """)
+        layout.addWidget(title, 0, Qt.AlignmentFlag.AlignVCenter)
+
+        layout.addSpacing(54)
+
+        self._nav_group = QButtonGroup(self)
+        self._nav_group.setExclusive(True)
+        tabs = [
+            ("工作流", "titleTab_workflow"),
+            ("模型", "titleTab_model"),
+            ("预览", "titleTab_preview"),
+            ("训练", "titleTab_training"),
+        ]
+        for index, (text, object_name) in enumerate(tabs):
+            button = TitleNavButton(text, object_name, self)
+            self._nav_group.addButton(button, index)
+            layout.addWidget(button, 0, Qt.AlignmentFlag.AlignVCenter)
+
+        self._nav_group.button(0).setChecked(True)
+        self._nav_group.idClicked.connect(self.view_changed.emit)
+
+        layout.addStretch(1)
+
+        settings_btn = WindowControlButton("⚙", "titleSettingsButton", self)
+        minimize_btn = WindowControlButton("–", "windowMinimizeButton", self)
+        maximize_btn = WindowControlButton("□", "windowMaximizeButton", self)
+        close_btn = WindowControlButton("×", "windowCloseButton", self, danger=True)
+
+        settings_btn.clicked.connect(self.settings_requested)
+        minimize_btn.clicked.connect(self.minimize_requested)
+        maximize_btn.clicked.connect(self.maximize_restore_requested)
+        close_btn.clicked.connect(self.close_requested)
+
+        layout.addWidget(settings_btn, 0, Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(minimize_btn, 0, Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(maximize_btn, 0, Qt.AlignmentFlag.AlignVCenter)
+        layout.addWidget(close_btn, 0, Qt.AlignmentFlag.AlignVCenter)

--- a/tests/test_custom_title_bar.py
+++ b/tests/test_custom_title_bar.py
@@ -1,0 +1,89 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QLabel, QMenuBar, QPushButton, QWidget
+
+from src.app import AudioTrainingApp
+
+
+def test_main_window_uses_compact_custom_title_bar():
+    app = QApplication.instance() or QApplication([])
+    window = AudioTrainingApp()
+
+    try:
+        assert window.windowFlags() & Qt.WindowType.FramelessWindowHint
+
+        title_bar = window.findChild(QWidget, "appTitleBar")
+        assert title_bar is not None
+        assert 42 <= title_bar.height() <= 48
+
+        title_label = window.findChild(QLabel, "appTitleLabel")
+        assert title_label is not None
+        assert title_label.text() == "AI 声学信号训练平台"
+
+        selected_tab = window.findChild(QPushButton, "titleTab_workflow")
+        assert selected_tab is not None
+        assert selected_tab.isChecked()
+    finally:
+        window.close()
+        app.processEvents()
+
+
+def test_maximize_restore_uses_custom_state_when_qt_state_lags(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    window = AudioTrainingApp()
+
+    try:
+        window._toggle_maximized()
+        app.processEvents()
+
+        assert window._custom_is_maximized is True
+
+        monkeypatch.setattr(window, "isMaximized", lambda: False)
+
+        window._toggle_maximized()
+        app.processEvents()
+
+        assert window._custom_is_maximized is False
+        assert not (window.windowState() & Qt.WindowState.WindowMaximized)
+    finally:
+        window.close()
+        app.processEvents()
+
+
+def test_settings_action_is_moved_to_title_bar_button(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+    window = AudioTrainingApp()
+
+    try:
+        opened = []
+
+        class FakeSignal:
+            def connect(self, callback):
+                self.callback = callback
+
+        class FakeSettingsDialog:
+            def __init__(self, parent=None):
+                self.settings_changed = FakeSignal()
+
+            def exec(self):
+                opened.append(True)
+
+        monkeypatch.setattr("src.app.SettingsDialog", FakeSettingsDialog)
+
+        settings_button = window.findChild(QPushButton, "titleSettingsButton")
+        assert settings_button is not None
+        assert settings_button.text() == "⚙"
+
+        menu_bar = window.findChild(QMenuBar)
+        top_level_menu_texts = [action.text() for action in menu_bar.actions()]
+        assert all("Edit" not in text and "编辑" not in text for text in top_level_menu_texts)
+
+        settings_button.click()
+
+        assert opened == [True]
+    finally:
+        window.close()
+        app.processEvents()


### PR DESCRIPTION
## Summary

- Added a frameless compact desktop title bar with app branding, primary navigation tabs, and custom window controls.
- Moved settings access from the Edit menu into a title-bar gear button while preserving the `Ctrl+,` shortcut.
- Added regression coverage for title-bar structure, maximize/restore behavior, and settings access.

## Related Issue

Closes #84

## Test Plan

- [x] `.\.venv\Scripts\python.exe -m pytest tests/test_custom_title_bar.py tests/test_workflow_tabs_style.py tests/test_about_dialog.py -q`
- [x] Manual smoke test by user found no issues.