### PR TITLE
feat(ui): add grouped workflow and model toolbars

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4,11 +4,10 @@ Main Application Class
 
 from collections.abc import Callable
 
-from PySide6.QtCore import QRect, Qt, QSize
+from PySide6.QtCore import QRect, Qt
 from PySide6.QtGui import QAction, QIcon, QKeySequence
 from PySide6.QtWidgets import (
-    QFileDialog, QMainWindow, QMenu, QMenuBar,
-    QMessageBox, QToolBar, QVBoxLayout, QWidget
+    QFileDialog, QMainWindow, QMessageBox, QVBoxLayout, QWidget
 )
 
 from src.ui.dialogs.about_dialog import AboutDialog
@@ -53,7 +52,7 @@ class AudioTrainingApp(QMainWindow):
         self._normal_geometry = QRect()
         self._init_ui()
         self._report_startup_progress(84, "Main window created...")
-        self._init_menubar()
+        self._init_actions()
         self._init_toolbar()
         self._init_connections()
         self._report_startup_progress(90, "Restoring previous session...")
@@ -96,116 +95,56 @@ class AudioTrainingApp(QMainWindow):
         # 居中显示
         self._center_window()
     
-    def _init_menubar(self):
-        """初始化菜单栏"""
-        menubar = QMenuBar(self)
-        self._root_layout.insertWidget(1, menubar)
-        menubar.setStyleSheet("""
-            QMenuBar {
-                background-color: #181825;
-                color: #cdd6f4;
-                padding: 4px;
-                border-bottom: 1px solid #313244;
-            }
-            QMenuBar::item {
-                padding: 6px 12px;
-                border-radius: 4px;
-            }
-            QMenuBar::item:selected {
-                background-color: #313244;
-            }
-            QMenu {
-                background-color: #1e1e2e;
-                color: #cdd6f4;
-                border: 1px solid #45475a;
-                border-radius: 4px;
-                padding: 4px;
-            }
-            QMenu::item {
-                padding: 8px 24px;
-                border-radius: 4px;
-            }
-            QMenu::item:selected {
-                background-color: #313244;
-            }
-            QMenu::separator {
-                height: 1px;
-                background-color: #45475a;
-                margin: 4px 8px;
-            }
-        """)
-        
-        # === 文件菜单 ===
-        file_menu = menubar.addMenu(tr_("File(&F)"))
-        
-        # 加载模型
+    def _init_actions(self):
+        """Initialize application shortcuts without rendering a menu bar."""
         self.action_load_model = QAction(tr_("Load model..."), self)
         self.action_load_model.setShortcut(QKeySequence("Ctrl+L"))
         self.action_load_model.triggered.connect(self._load_model)
-        file_menu.addAction(self.action_load_model)
-        
-        # 导出模型
+        self.addAction(self.action_load_model)
+
         self.action_export_model = QAction(tr_("Export model..."), self)
         self.action_export_model.setShortcut(QKeySequence("Ctrl+E"))
         self.action_export_model.triggered.connect(self._export_model)
-        file_menu.addAction(self.action_export_model)
-        
-        file_menu.addSeparator()
-        
-        # Recent workflows
-        self.recent_menu = file_menu.addMenu(tr_(RECENT_WORKFLOWS_MENU_TEXT))
-        self._update_recent_menu()
-        
-        file_menu.addSeparator()
-        
-        # 重启应用
+        self.addAction(self.action_export_model)
+
         self.action_restart = QAction(tr_("Restart(&R)"), self)
         self.action_restart.setShortcut(QKeySequence("Ctrl+Shift+R"))
         self.action_restart.triggered.connect(self._request_restart)
-        file_menu.addAction(self.action_restart)
+        self.addAction(self.action_restart)
 
-        file_menu.addSeparator()
-
-        # 退出
         self.action_exit = QAction(tr_("Exit(&X)"), self)
         self.action_exit.setShortcut(QKeySequence("Alt+F4"))
         self.action_exit.triggered.connect(self.close)
-        file_menu.addAction(self.action_exit)
-        
+        self.addAction(self.action_exit)
+
         self.action_settings = QAction(tr_("Settings..."), self)
         self.action_settings.setShortcut(QKeySequence("Ctrl+,"))
         self.action_settings.triggered.connect(self._show_settings)
         self.addAction(self.action_settings)
-        
-        # === 视图菜单 ===
-        view_menu = menubar.addMenu(tr_("View(&V)"))
-        
+
         self.action_view_workflow = QAction(tr_("Workflow view"), self)
         self.action_view_workflow.setShortcut(QKeySequence("Ctrl+1"))
         self.action_view_workflow.triggered.connect(lambda: self._switch_view(0))
-        view_menu.addAction(self.action_view_workflow)
-        
+        self.addAction(self.action_view_workflow)
+
         self.action_view_model = QAction(tr_("Model view"), self)
         self.action_view_model.setShortcut(QKeySequence("Ctrl+2"))
         self.action_view_model.triggered.connect(lambda: self._switch_view(1))
-        view_menu.addAction(self.action_view_model)
-        
+        self.addAction(self.action_view_model)
+
         self.action_view_preview = QAction(tr_("Preview view"), self)
         self.action_view_preview.setShortcut(QKeySequence("Ctrl+3"))
         self.action_view_preview.triggered.connect(lambda: self._switch_view(2))
-        view_menu.addAction(self.action_view_preview)
-        
+        self.addAction(self.action_view_preview)
+
         self.action_view_training = QAction(tr_("Training view"), self)
         self.action_view_training.setShortcut(QKeySequence("Ctrl+4"))
         self.action_view_training.triggered.connect(lambda: self._switch_view(3))
-        view_menu.addAction(self.action_view_training)
-        
-        # === 帮助菜单 ===
-        help_menu = menubar.addMenu(tr_("Help(&H)"))
-        
+        self.addAction(self.action_view_training)
+
         self.action_about = QAction(tr_("About..."), self)
         self.action_about.triggered.connect(self._show_about)
-        help_menu.addAction(self.action_about)
+        self.addAction(self.action_about)
     
     def _init_toolbar(self):
         """初始化工具栏（已移除，功能整合到工作流视图工具栏）"""
@@ -403,6 +342,8 @@ class AudioTrainingApp(QMainWindow):
     
     def _update_recent_menu(self):
         """Update the recent workflows menu."""
+        if not hasattr(self, "recent_menu"):
+            return
         self.recent_menu.clear()
         recent_workflows = filter_recent_workflow_files(config.get_recent_files())
         

--- a/src/ui/model_editor/model_graph_widget.py
+++ b/src/ui/model_editor/model_graph_widget.py
@@ -493,6 +493,14 @@ class ModelGraphWidget(QWidget):
                 layer_ids.append(item.layer.layer_id)
         return layer_ids
 
+    def copy_selected(self) -> bool:
+        """Copy selected layers using the same behavior as the context menu."""
+        return self._copy_selected()
+
+    def delete_selected(self) -> None:
+        """Delete selected layers or connections using the same behavior as the context menu."""
+        self._delete_selected()
+
     def _copy_selected(self) -> bool:
         """Copy the selected layers and their internal connections."""
         if not self.model_graph:

--- a/src/ui/node_editor/node_graph.py
+++ b/src/ui/node_editor/node_graph.py
@@ -700,6 +700,14 @@ class NodeGraphWidget(QWidget):
                 node_ids.append(item.node.node_id)
         return node_ids
 
+    def copy_selected(self) -> bool:
+        """Copy selected nodes using the same behavior as the context menu."""
+        return self._copy_selected()
+
+    def delete_selected(self) -> None:
+        """Delete selected nodes or connections using the same behavior as the context menu."""
+        self._delete_selected()
+
     def _copy_selected(self) -> bool:
         """Copy the selected nodes and their internal connections."""
         if not self.workflow:

--- a/src/ui/views/model_builder_view.py
+++ b/src/ui/views/model_builder_view.py
@@ -10,10 +10,9 @@ import os
 from typing import Optional
 
 from PySide6.QtCore import Qt, QTimer, Signal
-from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (
-    QDialog, QFileDialog, QFrame, QHBoxLayout, QLabel, QMessageBox,
-    QPushButton, QSplitter, QTextEdit, QToolBar, QVBoxLayout, QWidget
+    QDialog, QFileDialog, QHBoxLayout, QLabel, QMessageBox,
+    QPushButton, QSplitter, QTextEdit, QVBoxLayout, QWidget
 )
 
 from src.model_builder.model_graph import ModelGraph
@@ -21,6 +20,7 @@ from src.ui.model_editor.layer_palette import LayerPalette
 from src.ui.model_editor.layer_property_panel import LayerPropertyPanel
 from src.ui.model_editor.model_graph_widget import ModelGraphWidget
 from src.ui.i18n import tr_
+from src.ui.widgets.command_toolbar import GroupedCommandToolbar, command_button
 from src.ui.styles import Styles
 from src.utils.config import config
 
@@ -108,131 +108,58 @@ class ModelBuilderView(QWidget):
     
     def _create_toolbar(self, layout):
         """创建工具栏"""
-        toolbar_frame = QFrame()
-        toolbar_frame.setFixedHeight(42)
-        toolbar_frame.setStyleSheet(f"""
-            QFrame {{
-                background: {Styles.COLORS['surface0']};
-                border-bottom: 1px solid {Styles.COLORS['surface1']};
-            }}
-        """)
-        
-        toolbar_layout = QHBoxLayout(toolbar_frame)
-        toolbar_layout.setContentsMargins(12, 4, 12, 4)
-        toolbar_layout.setSpacing(8)
-        
-        # 模型名称
-        self._model_name_label = QLabel(tr_("📐 New model"))
-        self._model_name_label.setStyleSheet(f"""
-            font-size: 14px;
-            font-weight: bold;
-            color: {Styles.COLORS['text']};
-        """)
-        toolbar_layout.addWidget(self._model_name_label)
-        
-        toolbar_layout.addStretch()
-        
-        # 按钮样式
-        btn_style = f"""
-            QPushButton {{
-                background: {Styles.COLORS['surface1']};
-                border: none;
-                border-radius: 4px;
-                padding: 6px 12px;
-                color: {Styles.COLORS['text']};
-            }}
-            QPushButton:hover {{
-                background: {Styles.COLORS['surface2']};
-            }}
-        """
-        
-        # 新建按钮
-        new_btn = QPushButton(tr_("📄 New"))
-        new_btn.setStyleSheet(btn_style)
+        toolbar_frame = GroupedCommandToolbar("modelCommandToolbar", self)
+
+        self._model_name_label = QLabel(tr_("📐 New model"), self)
+        self._model_name_label.hide()
+
+        new_btn = command_button(tr_("📄 新建"), "modelToolbarButton_new", parent=toolbar_frame)
         new_btn.clicked.connect(self._on_new)
-        toolbar_layout.addWidget(new_btn)
-        
-        # 打开按钮
-        open_btn = QPushButton(tr_("📂 Open"))
-        open_btn.setStyleSheet(btn_style)
+
+        open_btn = command_button(tr_("📂 打开"), "modelToolbarButton_open", parent=toolbar_frame)
         open_btn.clicked.connect(self._on_open)
-        toolbar_layout.addWidget(open_btn)
-        
-        # 保存按钮
-        save_btn = QPushButton(tr_("💾 Save"))
-        save_btn.setStyleSheet(btn_style)
+
+        save_btn = command_button(tr_("💾 保存"), "modelToolbarButton_save", parent=toolbar_frame)
         save_btn.clicked.connect(self._on_save)
-        toolbar_layout.addWidget(save_btn)
-        
-        # 另存为按钮
-        save_as_btn = QPushButton(tr_("📋 Save as"))
-        save_as_btn.setStyleSheet(btn_style)
+
+        save_as_btn = command_button(tr_("📋 另存为"), "modelToolbarButton_save_as", parent=toolbar_frame)
         save_as_btn.clicked.connect(self._on_save_as)
-        toolbar_layout.addWidget(save_as_btn)
-        
-        # 分隔1
-        separator1 = QFrame()
-        separator1.setFrameShape(QFrame.Shape.VLine)
-        separator1.setStyleSheet(f"background: {Styles.COLORS['surface2']};")
-        separator1.setFixedWidth(1)
-        toolbar_layout.addWidget(separator1)
-        
-        # 导入Keras按钮
-        import_btn = QPushButton(tr_("📥 Import Keras"))
-        import_btn.setStyleSheet(f"""
-            QPushButton {{
-                background: {Styles.COLORS['peach']};
-                border: none;
-                border-radius: 4px;
-                padding: 6px 12px;
-                color: {Styles.COLORS['crust']};
-                font-weight: bold;
-            }}
-            QPushButton:hover {{
-                background: {Styles.COLORS['yellow']};
-            }}
-        """)
+        toolbar_frame.add_group("file", tr_("文件"), [new_btn, open_btn, save_btn, save_as_btn])
+
+        copy_btn = command_button(tr_("⧉ 复制"), "modelToolbarButton_copy", parent=toolbar_frame)
+        copy_btn.clicked.connect(self._graph_widget.copy_selected)
+        delete_btn = command_button(
+            tr_("🗑 删除"),
+            "modelToolbarButton_delete",
+            variant="danger",
+            parent=toolbar_frame,
+        )
+        delete_btn.clicked.connect(self._graph_widget.delete_selected)
+        toolbar_frame.add_group("edit", tr_("编辑"), [copy_btn, delete_btn])
+
+        build_btn = command_button(
+            tr_("🔨 构建模型"),
+            "modelToolbarButton_build",
+            variant="primary",
+            parent=toolbar_frame,
+        )
+        build_btn.clicked.connect(self._on_build)
+
+        import_btn = command_button(
+            tr_("📥 导入Keras"),
+            "modelToolbarButton_import_keras",
+            variant="warning",
+            parent=toolbar_frame,
+        )
         import_btn.setToolTip(tr_("Import architecture from a trained .keras/.h5 model file"))
         import_btn.clicked.connect(self._on_import_keras)
-        toolbar_layout.addWidget(import_btn)
-        
-        # 分隔2
-        separator2 = QFrame()
-        separator2.setFrameShape(QFrame.Shape.VLine)
-        separator2.setStyleSheet(f"background: {Styles.COLORS['surface2']};")
-        separator2.setFixedWidth(1)
-        toolbar_layout.addWidget(separator2)
-        
-        # 构建按钮
-        build_btn = QPushButton(tr_("🔨 Build model"))
-        build_btn.setStyleSheet(f"""
-            QPushButton {{
-                background: {Styles.COLORS['green']};
-                border: none;
-                border-radius: 4px;
-                padding: 6px 16px;
-                color: {Styles.COLORS['crust']};
-                font-weight: bold;
-            }}
-            QPushButton:hover {{
-                background: {Styles.COLORS['teal']};
-            }}
-        """)
-        build_btn.clicked.connect(self._on_build)
-        toolbar_layout.addWidget(build_btn)
-        
-        # 适应视图按钮
-        fit_btn = QPushButton(tr_("🔍 Fit"))
-        fit_btn.setStyleSheet(btn_style)
+        toolbar_frame.add_group("model", tr_("模型"), [build_btn, import_btn])
+
+        fit_btn = command_button(tr_("⛶ 适应"), "modelToolbarButton_fit", parent=toolbar_frame)
         fit_btn.clicked.connect(self._graph_widget.fit_to_selection)
-        toolbar_layout.addWidget(fit_btn)
-        
-        # 清空按钮
-        clear_btn = QPushButton(tr_("🗑️ Clear"))
-        clear_btn.setStyleSheet(btn_style)
-        clear_btn.clicked.connect(self._on_clear)
-        toolbar_layout.addWidget(clear_btn)
-        
+        toolbar_frame.add_group("view", tr_("视图"), [fit_btn])
+        toolbar_frame.add_end_stretch()
+
         layout.addWidget(toolbar_frame)
     
     def _connect_signals(self):

--- a/src/ui/views/workflow_editor_widget.py
+++ b/src/ui/views/workflow_editor_widget.py
@@ -105,6 +105,12 @@ class WorkflowEditorWidget(QWidget):
     def fit_to_selection(self):
         self._node_graph.fit_to_selection()
 
+    def copy_selected(self) -> bool:
+        return self._node_graph.copy_selected()
+
+    def delete_selected(self) -> None:
+        self._node_graph.delete_selected()
+
     # ===== Internal event handlers =====
 
     def _on_add_node_from_palette(self, node_type: str):

--- a/src/ui/views/workflow_tabs_view.py
+++ b/src/ui/views/workflow_tabs_view.py
@@ -402,6 +402,9 @@ class WorkflowTabsView(QWidget):
         self._toolbar.new_requested.connect(self.new_tab)
         self._toolbar.open_requested.connect(self._open_dialog)
         self._toolbar.save_requested.connect(self._save_current)
+        self._toolbar.save_as_requested.connect(self._save_current_as)
+        self._toolbar.copy_requested.connect(self._copy_current_selection)
+        self._toolbar.delete_requested.connect(self._delete_current_selection)
         self._toolbar.duplicate_requested.connect(self.duplicate_current_tab)
         self._toolbar.run_requested.connect(self.run_requested)
         self._toolbar.stop_requested.connect(self._on_stop_workflow)
@@ -541,15 +544,21 @@ class WorkflowTabsView(QWidget):
         editor = self._current_editor()
         if not editor:
             return
-        self._save_editor(editor)
+        self._save_editor(editor, force_save_as=False)
 
-    def _save_editor(self, editor: WorkflowEditorWidget) -> bool:
+    def _save_current_as(self):
+        editor = self._current_editor()
+        if not editor:
+            return
+        self._save_editor(editor, force_save_as=True)
+
+    def _save_editor(self, editor: WorkflowEditorWidget, *, force_save_as: bool = False) -> bool:
         workflow = editor.get_workflow()
         if not workflow:
             return True
 
         file_path = getattr(workflow, "_file_path", None)
-        if file_path:
+        if file_path and not force_save_as:
             ok = workflow.save(file_path)
             if ok:
                 self._set_editor_session_file_path(editor, file_path)
@@ -583,6 +592,16 @@ class WorkflowTabsView(QWidget):
             self._refresh_all_tab_titles()
             self.persist_session_state_guarded()
         return bool(ok)
+
+    def _copy_current_selection(self):
+        editor = self._current_editor()
+        if editor:
+            editor.copy_selected()
+
+    def _delete_current_selection(self):
+        editor = self._current_editor()
+        if editor:
+            editor.delete_selected()
 
     def _on_stop_workflow(self):
         self.set_run_controls_state(

--- a/src/ui/views/workflow_toolbar.py
+++ b/src/ui/views/workflow_toolbar.py
@@ -10,21 +10,11 @@ Communicates purely via signals -- contains no workflow / editor logic.
 from typing import Optional
 
 from PySide6.QtCore import Signal
-from PySide6.QtWidgets import (
-    QFrame,
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QSizePolicy,
-    QStackedWidget,
-    QWidget,
-)
-
 from ..i18n import tr_
-from ..styles import Styles
+from ..widgets.command_toolbar import GroupedCommandToolbar, command_button
 
 
-class WorkflowToolbar(QFrame):
+class WorkflowToolbar(GroupedCommandToolbar):
     """
     Reusable workflow toolbar.
 
@@ -35,7 +25,10 @@ class WorkflowToolbar(QFrame):
     new_requested = Signal()
     open_requested = Signal()
     save_requested = Signal()
+    save_as_requested = Signal()
     duplicate_requested = Signal()
+    copy_requested = Signal()
+    delete_requested = Signal()
     run_requested = Signal()
     stop_requested = Signal()
     continue_requested = Signal()
@@ -43,14 +36,15 @@ class WorkflowToolbar(QFrame):
     clear_requested = Signal()
 
     def __init__(self, parent=None, *, show_duplicate: bool = False):
-        super().__init__(parent)
+        super().__init__("workflowCommandToolbar", parent)
         self._show_duplicate = show_duplicate
+        self._breakpoint_active = False
         self._setup_ui()
 
     # ===== Public API =====
 
     def set_title(self, text: str):
-        self._title_label.setText(f"🔧 {text}")
+        self.setToolTip(text)
 
     def set_run_controls_state(
         self,
@@ -63,148 +57,66 @@ class WorkflowToolbar(QFrame):
         self._stop_btn.setEnabled(stop_enabled)
         if stop_text is not None:
             self._stop_btn.setText(stop_text)
+        elif not self._stop_btn.text().endswith(tr_("停止")):
+            self._stop_btn.setText(tr_("⏹ 停止"))
 
     def show_breakpoint_mode(self, enabled: bool, node_name: str = ""):
-        self._run_control_stack.setCurrentIndex(1 if enabled else 0)
-        if enabled and node_name:
-            self._breakpoint_label.setText(f"🔴 {node_name}")
-        else:
-            self._breakpoint_label.setText(tr_("🔴 Paused"))
+        self._breakpoint_active = enabled
+        if enabled:
+            suffix = f" ({node_name})" if node_name else ""
+            self._run_btn.setText(tr_("⏵ 继续") + suffix)
+            self._run_btn.setEnabled(True)
+            return
+        self._run_btn.setText(tr_("▶ 运行"))
 
     # ===== UI construction =====
 
     def _setup_ui(self):
-        self.setFixedHeight(42)
-        self.setStyleSheet(f"""
-            QFrame {{
-                background: {Styles.COLORS['surface0']};
-                border-bottom: 1px solid {Styles.COLORS['surface1']};
-            }}
-        """)
-
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(12, 4, 12, 4)
-        layout.setSpacing(8)
-
-        self._title_label = QLabel("🔧 new_workflow")
-        self._title_label.setStyleSheet(f"""
-            font-size: 14px;
-            font-weight: bold;
-            color: {Styles.COLORS['text']};
-        """)
-        layout.addWidget(self._title_label)
-
-        layout.addStretch()
-
-        btn_style = f"""
-            QPushButton {{
-                background: {Styles.COLORS['surface1']};
-                border: none;
-                border-radius: 4px;
-                padding: 6px 12px;
-                color: {Styles.COLORS['text']};
-            }}
-            QPushButton:hover {{
-                background: {Styles.COLORS['surface2']};
-            }}
-        """
-
-        new_btn = QPushButton(tr_("📄 New"))
-        new_btn.setStyleSheet(btn_style)
+        new_btn = command_button(tr_("📄 新建"), "workflowToolbarButton_new", parent=self)
         new_btn.clicked.connect(self.new_requested)
-        layout.addWidget(new_btn)
-
-        open_btn = QPushButton(tr_("📂 Open"))
-        open_btn.setStyleSheet(btn_style)
+        open_btn = command_button(tr_("📂 打开"), "workflowToolbarButton_open", parent=self)
         open_btn.clicked.connect(self.open_requested)
-        layout.addWidget(open_btn)
-
-        save_btn = QPushButton(tr_("💾 Save"))
-        save_btn.setStyleSheet(btn_style)
+        save_btn = command_button(tr_("💾 保存"), "workflowToolbarButton_save", parent=self)
         save_btn.clicked.connect(self.save_requested)
-        layout.addWidget(save_btn)
+        save_as_btn = command_button(tr_("📋 另存为"), "workflowToolbarButton_save_as", parent=self)
+        save_as_btn.clicked.connect(self.save_as_requested)
+        self.add_group("file", tr_("文件"), [new_btn, open_btn, save_btn, save_as_btn])
 
-        if self._show_duplicate:
-            dup_btn = QPushButton(tr_("📑 Duplicate"))
-            dup_btn.setStyleSheet(btn_style)
-            dup_btn.clicked.connect(self.duplicate_requested)
-            layout.addWidget(dup_btn)
-
-        # Run / Stop / Breakpoint controls via QStackedWidget
-        self._run_control_stack = QStackedWidget()
-        self._run_control_stack.setFixedHeight(32)
-        self._run_control_stack.setSizePolicy(
-            QSizePolicy.Policy.Fixed,
-            QSizePolicy.Policy.Fixed,
+        copy_btn = command_button(tr_("⧉ 复制"), "workflowToolbarButton_copy", parent=self)
+        copy_btn.clicked.connect(self.copy_requested)
+        delete_btn = command_button(
+            tr_("🗑 删除"),
+            "workflowToolbarButton_delete",
+            variant="danger",
+            parent=self,
         )
-        self._run_control_stack.setStyleSheet("QStackedWidget { background: transparent; }")
+        delete_btn.clicked.connect(self.delete_requested)
+        self.add_group("edit", tr_("编辑"), [copy_btn, delete_btn])
 
-        # Page 0: normal mode (Run + Stop)
-        normal_widget = QWidget()
-        normal_widget.setStyleSheet("QWidget { background: transparent; }")
-        normal_layout = QHBoxLayout(normal_widget)
-        normal_layout.setContentsMargins(0, 0, 0, 0)
-        normal_layout.setSpacing(4)
-
-        self._run_btn = QPushButton(tr_("▶️ Run"))
-        self._run_btn.setStyleSheet(btn_style)
-        self._run_btn.clicked.connect(self.run_requested)
-        normal_layout.addWidget(self._run_btn)
-
-        self._stop_btn = QPushButton(tr_("⏹️ Stop"))
-        self._stop_btn.setStyleSheet(btn_style)
-        self._stop_btn.setEnabled(False)
+        self._run_btn = command_button(
+            tr_("▶ 运行"),
+            "workflowToolbarButton_run",
+            variant="primary",
+            parent=self,
+        )
+        self._run_btn.clicked.connect(self._emit_primary_run_action)
+        self._stop_btn = command_button(
+            tr_("⏹ 停止"),
+            "workflowToolbarButton_stop",
+            variant="danger",
+            enabled=False,
+            parent=self,
+        )
         self._stop_btn.clicked.connect(self.stop_requested)
-        normal_layout.addWidget(self._stop_btn)
+        self.add_group("run", tr_("运行"), [self._run_btn, self._stop_btn])
 
-        self._run_control_stack.addWidget(normal_widget)  # index 0
-
-        # Page 1: breakpoint mode (label + Continue)
-        breakpoint_widget = QWidget()
-        breakpoint_widget.setStyleSheet("QWidget { background: transparent; }")
-        breakpoint_layout = QHBoxLayout(breakpoint_widget)
-        breakpoint_layout.setContentsMargins(0, 0, 0, 0)
-        breakpoint_layout.setSpacing(4)
-
-        self._breakpoint_label = QLabel(tr_("🔴 Paused"))
-        self._breakpoint_label.setStyleSheet(f"""
-            QLabel {{
-                color: {Styles.COLORS['red']};
-                font-weight: bold;
-                padding: 6px 12px;
-                background: {Styles.COLORS['surface1']};
-                border-radius: 4px;
-            }}
-        """)
-        breakpoint_layout.addWidget(self._breakpoint_label)
-
-        continue_btn = QPushButton(tr_("⏵ Continue"))
-        continue_btn.setStyleSheet(f"""
-            QPushButton {{
-                background: {Styles.COLORS['green']};
-                border: none;
-                border-radius: 4px;
-                padding: 6px 12px;
-                color: {Styles.COLORS['crust']};
-                font-weight: bold;
-            }}
-            QPushButton:hover {{
-                background: {Styles.COLORS['teal']};
-            }}
-        """)
-        continue_btn.clicked.connect(self.continue_requested)
-        breakpoint_layout.addWidget(continue_btn)
-
-        self._run_control_stack.addWidget(breakpoint_widget)  # index 1
-        self._run_control_stack.setCurrentIndex(0)
-        layout.addWidget(self._run_control_stack)
-
-        fit_btn = QPushButton(tr_("🔍 Fit"))
-        fit_btn.setStyleSheet(btn_style)
+        fit_btn = command_button(tr_("⛶ 适应"), "workflowToolbarButton_fit", parent=self)
         fit_btn.clicked.connect(self.fit_requested)
-        layout.addWidget(fit_btn)
+        self.add_group("view", tr_("视图"), [fit_btn])
+        self.add_end_stretch()
 
-        clear_btn = QPushButton(tr_("🗑️ Clear"))
-        clear_btn.setStyleSheet(btn_style)
-        clear_btn.clicked.connect(self.clear_requested)
-        layout.addWidget(clear_btn)
+    def _emit_primary_run_action(self) -> None:
+        if self._breakpoint_active:
+            self.continue_requested.emit()
+        else:
+            self.run_requested.emit()

--- a/src/ui/views/workflow_view.py
+++ b/src/ui/views/workflow_view.py
@@ -76,6 +76,9 @@ class WorkflowView(QWidget):
             self._toolbar.new_requested.connect(self._on_new_workflow)
             self._toolbar.open_requested.connect(self._on_open_workflow)
             self._toolbar.save_requested.connect(self._on_save_workflow)
+            self._toolbar.save_as_requested.connect(self._on_save_workflow_as)
+            self._toolbar.copy_requested.connect(self._editor.copy_selected)
+            self._toolbar.delete_requested.connect(self._editor.delete_selected)
             self._toolbar.run_requested.connect(self.run_requested)
             self._toolbar.stop_requested.connect(self._on_stop_workflow)
             self._toolbar.continue_requested.connect(self.continue_requested)
@@ -167,27 +170,37 @@ class WorkflowView(QWidget):
                     pass
 
     def _on_save_workflow(self):
+        self._save_workflow(force_save_as=False)
+
+    def _on_save_workflow_as(self):
+        self._save_workflow(force_save_as=True)
+
+    def _save_workflow(self, *, force_save_as: bool):
         from PySide6.QtWidgets import QFileDialog
 
         workflow = self._editor.get_workflow()
         if not workflow:
             return
 
-        path, _ = QFileDialog.getSaveFileName(
-            self,
-            tr_("Save workflow"),
-            f"workflows/{workflow.name}.json",
-            tr_("Workflow files (*.json)"),
-        )
-        if path:
-            workflow.save(path)
-            workflow._file_path = path
-            self._update_toolbar_title()
-            try:
-                config.set("session.last_workflow_path", path)
-                config.add_recent_file(path)
-            except Exception:
-                pass
+        path = getattr(workflow, "_file_path", None)
+        if force_save_as or not path:
+            path, _ = QFileDialog.getSaveFileName(
+                self,
+                tr_("Save workflow"),
+                f"workflows/{workflow.name}.json",
+                tr_("Workflow files (*.json)"),
+            )
+            if not path:
+                return
+
+        workflow.save(path)
+        workflow._file_path = path
+        self._update_toolbar_title()
+        try:
+            config.set("session.last_workflow_path", path)
+            config.add_recent_file(path)
+        except Exception:
+            pass
 
     def _on_stop_workflow(self):
         from src.core.event_bus import get_event_bus

--- a/src/ui/widgets/command_toolbar.py
+++ b/src/ui/widgets/command_toolbar.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""Shared grouped command toolbar widgets."""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+from src.ui.styles import Styles
+
+
+class GroupedCommandToolbar(QFrame):
+    """Compact dark toolbar with titled command groups."""
+
+    def __init__(self, object_name: str, parent=None):
+        super().__init__(parent)
+        self.setObjectName(object_name)
+        self.setFixedHeight(60)
+        self.setStyleSheet(f"""
+            QFrame#{object_name} {{
+                background: qlineargradient(
+                    x1: 0, y1: 0, x2: 1, y2: 0,
+                    stop: 0 #111827,
+                    stop: 0.55 {Styles.COLORS['mantle']},
+                    stop: 1 #151a2c
+                );
+                border-top: 1px solid rgba(88, 91, 112, 0.38);
+                border-bottom: 1px solid rgba(88, 91, 112, 0.72);
+            }}
+            QLabel[role="groupTitle"] {{
+                color: {Styles.COLORS['subtext1']};
+                font-size: 11px;
+                font-weight: 600;
+                padding: 0 1px;
+            }}
+            QFrame[role="toolbarSeparator"] {{
+                background: rgba(88, 91, 112, 0.58);
+                min-width: 1px;
+                max-width: 1px;
+            }}
+        """)
+
+        self._layout = QHBoxLayout(self)
+        self._layout.setContentsMargins(16, 5, 16, 5)
+        self._layout.setSpacing(16)
+
+    def add_group(self, key: str, title: str, buttons: list[QPushButton]) -> None:
+        group = QWidget(self)
+        group.setObjectName(f"toolbarGroup_{key}")
+        group_layout = QVBoxLayout(group)
+        group_layout.setContentsMargins(0, 0, 0, 0)
+        group_layout.setSpacing(4)
+
+        title_label = QLabel(title, group)
+        title_label.setObjectName(f"toolbarGroupTitle_{key}")
+        title_label.setProperty("role", "groupTitle")
+        group_layout.addWidget(title_label, 0, Qt.AlignmentFlag.AlignLeft)
+
+        button_row = QWidget(group)
+        button_row.setObjectName(f"toolbarGroupButtons_{key}")
+        button_layout = QHBoxLayout(button_row)
+        button_layout.setContentsMargins(0, 0, 0, 0)
+        button_layout.setSpacing(6)
+        for button in buttons:
+            button_layout.addWidget(button)
+        group_layout.addWidget(button_row)
+
+        if self._layout.count() > 0:
+            self._layout.addWidget(self._separator())
+        self._layout.addWidget(group, 0, Qt.AlignmentFlag.AlignVCenter)
+
+    def add_end_stretch(self) -> None:
+        self._layout.addStretch(1)
+
+    def _separator(self) -> QFrame:
+        separator = QFrame(self)
+        separator.setProperty("role", "toolbarSeparator")
+        separator.setFixedHeight(38)
+        return separator
+
+
+def command_button(
+    text: str,
+    object_name: str,
+    *,
+    variant: str = "normal",
+    enabled: bool = True,
+    parent=None,
+) -> QPushButton:
+    """Create a consistently styled toolbar command button."""
+    button = QPushButton(text, parent)
+    button.setObjectName(object_name)
+    button.setCursor(Qt.CursorShape.PointingHandCursor)
+    button.setFixedHeight(26)
+    button.setMinimumWidth(58)
+    button.setEnabled(enabled)
+
+    palettes = {
+        "normal": ("#252b3b", "#3a4257", Styles.COLORS["text"], "#596176"),
+        "primary": ("#2d6a4f", "#40916c", "#f4fff8", "#52b788"),
+        "danger": ("#5a2530", "#7a3442", "#ffe7ec", "#9a4556"),
+        "warning": ("#57402f", "#73543c", "#fff3df", "#8a6749"),
+    }
+    bg, hover, fg, border = palettes.get(variant, palettes["normal"])
+    disabled_fg = Styles.COLORS["overlay0"]
+
+    button.setStyleSheet(f"""
+        QPushButton#{object_name} {{
+            background: {bg};
+            border: 1px solid {border};
+            border-radius: 5px;
+            color: {fg};
+            font-size: 12px;
+            font-weight: 500;
+            padding: 4px 9px;
+        }}
+        QPushButton#{object_name}:hover {{
+            background: {hover};
+            border-color: {Styles.COLORS['blue']};
+        }}
+        QPushButton#{object_name}:pressed {{
+            background: {Styles.COLORS['surface1']};
+        }}
+        QPushButton#{object_name}:disabled {{
+            background: #1b2130;
+            border-color: #30364a;
+            color: {disabled_fg};
+        }}
+    """)
+    return button

--- a/tests/test_custom_title_bar.py
+++ b/tests/test_custom_title_bar.py
@@ -53,7 +53,7 @@ def test_maximize_restore_uses_custom_state_when_qt_state_lags(monkeypatch):
         app.processEvents()
 
 
-def test_settings_action_is_moved_to_title_bar_button(monkeypatch):
+def test_settings_action_is_available_from_title_bar_without_menu_bar(monkeypatch):
     app = QApplication.instance() or QApplication([])
     window = AudioTrainingApp()
 
@@ -77,9 +77,7 @@ def test_settings_action_is_moved_to_title_bar_button(monkeypatch):
         assert settings_button is not None
         assert settings_button.text() == "⚙"
 
-        menu_bar = window.findChild(QMenuBar)
-        top_level_menu_texts = [action.text() for action in menu_bar.actions()]
-        assert all("Edit" not in text and "编辑" not in text for text in top_level_menu_texts)
+        assert window.findChild(QMenuBar) is None
 
         settings_button.click()
 

--- a/tests/test_grouped_toolbars.py
+++ b/tests/test_grouped_toolbars.py
@@ -1,0 +1,91 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication, QLabel, QPushButton, QWidget
+
+from src.ui.views.model_builder_view import ModelBuilderView
+from src.ui.views.workflow_toolbar import WorkflowToolbar
+
+
+def _texts_for_labels(parent: QWidget, prefix: str) -> list[str]:
+    return [
+        label.text()
+        for label in parent.findChildren(QLabel)
+        if label.objectName().startswith(prefix)
+    ]
+
+
+def _button(parent: QWidget, object_name: str) -> QPushButton:
+    button = parent.findChild(QPushButton, object_name)
+    assert button is not None, object_name
+    return button
+
+
+def test_workflow_toolbar_uses_grouped_command_layout():
+    app = QApplication.instance() or QApplication([])
+    toolbar = WorkflowToolbar(show_duplicate=True)
+
+    try:
+        assert toolbar.objectName() == "workflowCommandToolbar"
+        assert 54 <= toolbar.height() <= 64
+        assert _texts_for_labels(toolbar, "toolbarGroupTitle_") == [
+            "文件",
+            "编辑",
+            "运行",
+            "视图",
+        ]
+
+        expected_buttons = {
+            "workflowToolbarButton_new": "新建",
+            "workflowToolbarButton_open": "打开",
+            "workflowToolbarButton_save": "保存",
+            "workflowToolbarButton_save_as": "另存为",
+            "workflowToolbarButton_copy": "复制",
+            "workflowToolbarButton_delete": "删除",
+            "workflowToolbarButton_run": "运行",
+            "workflowToolbarButton_stop": "停止",
+            "workflowToolbarButton_fit": "适应",
+        }
+        for object_name, label in expected_buttons.items():
+            assert label in _button(toolbar, object_name).text()
+
+        assert _button(toolbar, "workflowToolbarButton_save_as").isEnabled()
+        assert _button(toolbar, "workflowToolbarButton_copy").isEnabled()
+        assert _button(toolbar, "workflowToolbarButton_delete").isEnabled()
+    finally:
+        toolbar.close()
+        app.processEvents()
+
+
+def test_model_builder_toolbar_uses_matching_grouped_command_layout():
+    app = QApplication.instance() or QApplication([])
+    view = ModelBuilderView()
+
+    try:
+        toolbar = view.findChild(QWidget, "modelCommandToolbar")
+        assert toolbar is not None
+        assert 54 <= toolbar.height() <= 64
+        assert _texts_for_labels(toolbar, "toolbarGroupTitle_") == [
+            "文件",
+            "编辑",
+            "模型",
+            "视图",
+        ]
+
+        expected_buttons = {
+            "modelToolbarButton_new": "新建",
+            "modelToolbarButton_open": "打开",
+            "modelToolbarButton_save": "保存",
+            "modelToolbarButton_save_as": "另存为",
+            "modelToolbarButton_copy": "复制",
+            "modelToolbarButton_delete": "删除",
+            "modelToolbarButton_build": "构建模型",
+            "modelToolbarButton_import_keras": "导入Keras",
+            "modelToolbarButton_fit": "适应",
+        }
+        for object_name, label in expected_buttons.items():
+            assert label in _button(toolbar, object_name).text()
+    finally:
+        view.close()
+        app.processEvents()


### PR DESCRIPTION
## Summary
- Add a shared grouped command toolbar component and apply it to the workflow and model pages only.
- Remove the global menu bar while preserving application shortcuts/actions.
- Wire toolbar buttons to existing workflow/model capabilities and add UI coverage for the new layout.

## Related Issue
Closes #86

## Test Plan
- [x] `python -m pytest tests/test_grouped_toolbars.py tests/test_custom_title_bar.py tests/test_workflow_tabs_style.py tests/test_graph_copy_paste.py -q`
- [x] Manual smoke test by user
