### PR TITLE
feat(ui): add canvas workspace document tabs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -261,43 +261,89 @@ class AudioTrainingApp(QMainWindow):
         # ===== 恢复模型编辑器 =====
         try:
             self._report_startup_progress(94, "Restoring model editor state...")
+            try:
+                self.main_window._model_builder_view.set_session_restore_in_progress(True)
+            except Exception:
+                pass
+
             model_graph = None
             model_file_path = None
+            open_model_paths = config.get("session.open_model_paths", [])
+            active_model_idx = config.get("session.active_model_tab", -1)
+            restored_model_paths: list[str] = []
+            if isinstance(open_model_paths, list):
+                for p in open_model_paths:
+                    if isinstance(p, str) and p and os.path.exists(p):
+                        restored_model_paths.append(p)
 
-            last_model_path = config.get('session.last_model_path')
-            if last_model_path and os.path.exists(last_model_path):
+            if restored_model_paths:
                 try:
-                    model_graph = ModelGraph.load(last_model_path)
-                    model_file_path = last_model_path
+                    self.main_window._model_builder_view.clear_all_tabs(ensure_one_tab=False)
                 except Exception:
-                    model_graph = None
+                    pass
 
-            if model_graph is None:
-                snapshot = config.get('session.last_model_graph_snapshot')
-                if isinstance(snapshot, dict):
+                for p in restored_model_paths:
                     try:
-                        model_graph = ModelGraph.from_dict(snapshot)
-                        model_file_path = None
+                        self.main_window._model_builder_view.open_model_file(p)
+                    except Exception:
+                        pass
+
+                try:
+                    count = int(self.main_window._model_builder_view._tabs.count())
+                except Exception:
+                    count = 0
+                if count > 0:
+                    try:
+                        idx = int(active_model_idx)
+                    except Exception:
+                        idx = -1
+                    if idx < 0 or idx >= count:
+                        idx = 0
+                    try:
+                        self.main_window._model_builder_view._tabs.setCurrentIndex(idx)
+                    except Exception:
+                        pass
+            else:
+                last_model_path = config.get('session.last_model_path')
+                if last_model_path and os.path.exists(last_model_path):
+                    try:
+                        model_graph = ModelGraph.load(last_model_path)
+                        model_file_path = last_model_path
                     except Exception:
                         model_graph = None
 
-            if model_graph is not None:
-                try:
-                    self.main_window._model_builder_view.set_model_graph(
-                        model_graph,
-                        file_path=model_file_path
-                    )
-                except Exception:
-                    # 不阻断启动；最差情况保持默认模型
-                    pass
+                if model_graph is None:
+                    snapshot = config.get('session.last_model_graph_snapshot')
+                    if isinstance(snapshot, dict):
+                        try:
+                            model_graph = ModelGraph.from_dict(snapshot)
+                            model_file_path = None
+                        except Exception:
+                            model_graph = None
 
-            if model_file_path:
-                try:
-                    config.add_recent_file(model_file_path)
-                except Exception:
-                    pass
+                if model_graph is not None:
+                    try:
+                        self.main_window._model_builder_view.set_model_graph(
+                            model_graph,
+                            file_path=model_file_path
+                        )
+                    except Exception:
+                        # Startup restore should not block the app; the default model remains usable.
+                        pass
+
+                if model_file_path:
+                    try:
+                        config.add_recent_file(model_file_path)
+                    except Exception:
+                        pass
         except Exception:
             pass
+        finally:
+            try:
+                self.main_window._model_builder_view.set_session_restore_in_progress(False)
+                self.main_window._model_builder_view.persist_session_state_guarded()
+            except Exception:
+                pass
         self._report_startup_progress(95, "Startup state restored...")
     
     def _center_window(self):

--- a/src/ui/styles.py
+++ b/src/ui/styles.py
@@ -174,6 +174,67 @@ class Styles:
                 background-color: #585b70;
             }}
         """
+
+    @staticmethod
+    def canvas_tab_widget() -> str:
+        """Return the shared dark IDE-style tab strip used above graph canvases."""
+        return f"""
+            QTabWidget {{
+                background: {Styles.COLORS['base']};
+            }}
+            QTabWidget::pane {{
+                border: 1px solid {Styles.COLORS['surface1']};
+                border-top: 1px solid {Styles.COLORS['surface1']};
+                background: {Styles.COLORS['base']};
+            }}
+            QTabWidget::tab-bar {{
+                alignment: left;
+            }}
+            QTabBar {{
+                background: {Styles.COLORS['mantle']};
+                border-top: 1px solid rgba(88, 91, 112, 0.36);
+                border-bottom: 1px solid {Styles.COLORS['surface1']};
+            }}
+            QTabBar::tab {{
+                background: rgba(49, 50, 68, 0.72);
+                color: {Styles.COLORS['subtext1']};
+                border: 1px solid {Styles.COLORS['surface1']};
+                border-bottom: 2px solid transparent;
+                border-top-left-radius: 6px;
+                border-top-right-radius: 6px;
+                padding: 7px 14px 6px 14px;
+                margin-right: 2px;
+                min-width: 110px;
+            }}
+            QTabBar::tab:selected {{
+                background: {Styles.COLORS['surface2']};
+                color: {Styles.COLORS['text']};
+                border-color: {Styles.COLORS['blue']};
+                border-bottom: 2px solid {Styles.COLORS['blue']};
+            }}
+            QTabBar::tab:!selected {{
+                background: rgba(49, 50, 68, 0.62);
+                color: {Styles.COLORS['subtext1']};
+            }}
+            QTabBar::tab:hover {{
+                background: {Styles.COLORS['surface1']};
+                color: {Styles.COLORS['text']};
+                border-bottom: 2px solid {Styles.COLORS['lavender']};
+            }}
+            QToolButton {{
+                background: {Styles.COLORS['surface0']};
+                color: {Styles.COLORS['text']};
+                border: 1px solid {Styles.COLORS['surface1']};
+                border-radius: 5px;
+                padding: 4px 10px;
+                margin: 3px;
+                font-weight: 700;
+            }}
+            QToolButton:hover {{
+                background: {Styles.COLORS['surface1']};
+                border-color: {Styles.COLORS['blue']};
+            }}
+        """
     
     # ===== 按钮样式 =====
     BUTTON_PRIMARY = """

--- a/src/ui/views/model_builder_view.py
+++ b/src/ui/views/model_builder_view.py
@@ -7,12 +7,13 @@ Provides visual drag-and-drop neural network model building interface.
 
 import logging
 import os
+from dataclasses import dataclass
 from typing import Optional
 
 from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtWidgets import (
     QDialog, QFileDialog, QHBoxLayout, QLabel, QMessageBox,
-    QPushButton, QSplitter, QTextEdit, QVBoxLayout, QWidget
+    QPushButton, QSplitter, QTabWidget, QTextEdit, QToolButton, QVBoxLayout, QWidget
 )
 
 from src.model_builder.model_graph import ModelGraph
@@ -25,6 +26,14 @@ from src.ui.styles import Styles
 from src.utils.config import config
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ModelTab:
+    graph_widget: ModelGraphWidget
+    model_graph: ModelGraph
+    file_path: Optional[str] = None
+    source_keras_model: object = None
 
 
 class ModelBuilderView(QWidget):
@@ -44,6 +53,7 @@ class ModelBuilderView(QWidget):
         self._model_graph: Optional[ModelGraph] = None
         self._current_file_path: Optional[str] = None
         self._source_keras_model = None  # 导入的 Keras 模型引用（用于权重迁移）
+        self._session_restore_in_progress: bool = True
 
         # 快照持久化防抖（避免每次拖拽/编辑都写磁盘）
         self._snapshot_timer = QTimer(self)
@@ -62,49 +72,136 @@ class ModelBuilderView(QWidget):
         """
         外部注入/恢复模型图（用于启动恢复或外部加载）。
         """
-        self._model_graph = model_graph
-        self._current_file_path = file_path
-        self._source_keras_model = None
+        if self._tabs.count() == 0:
+            self._add_model_tab(model_graph=model_graph, file_path=file_path, make_current=True)
+            return
 
-        self._graph_widget.set_model_graph(self._model_graph)
+        tab = self._current_tab()
+        if not tab:
+            self._add_model_tab(model_graph=model_graph, file_path=file_path, make_current=True)
+            return
+
+        tab.model_graph = model_graph
+        tab.file_path = file_path
+        tab.source_keras_model = None
+        tab.graph_widget.set_model_graph(model_graph)
+        self._sync_current_model_state()
         self._property_panel.set_layer(None)
-        self._property_panel.set_compile_config(self._model_graph.compile_config)
-        self._update_title()
+        self._property_panel.set_compile_config(model_graph.compile_config)
+        self._refresh_all_tab_titles()
+
+    def set_session_restore_in_progress(self, enabled: bool) -> None:
+        self._session_restore_in_progress = bool(enabled)
+
+    def persist_session_state(self) -> None:
+        self.persist_session_state_guarded()
+
+    def persist_session_state_guarded(self, *, force: bool = False) -> None:
+        if self._session_restore_in_progress and not force:
+            return
+
+        paths: list[str] = []
+        active = -1
+        current = self._tabs.currentIndex() if hasattr(self, "_tabs") else -1
+        for index in range(self._tabs.count()):
+            tab = self._get_tab(index)
+            if tab is None or not tab.file_path:
+                continue
+            path = os.path.abspath(tab.file_path)
+            if not os.path.exists(path):
+                continue
+            if index == current:
+                active = len(paths)
+            paths.append(path)
+
+        try:
+            config.set("session.open_model_paths", paths)
+            config.set("session.active_model_tab", active)
+        except Exception:
+            pass
+
+    def clear_all_tabs(self, *, ensure_one_tab: bool = True) -> None:
+        while self._tabs.count() > 0:
+            widget = self._tabs.widget(0)
+            self._tabs.removeTab(0)
+            if widget is not None:
+                widget.deleteLater()
+
+        if ensure_one_tab:
+            self._add_model_tab(model_graph=ModelGraph("new_model"), file_path=None, make_current=True)
+        else:
+            self._sync_current_model_state()
+
+        self.persist_session_state_guarded()
+
+    def open_model_file(self, path: str):
+        model_graph = ModelGraph.load(path)
+        self._add_model_tab(model_graph=model_graph, file_path=path, make_current=True)
+        try:
+            config.set("session.last_model_path", path)
+            config.add_recent_file(path)
+        except Exception:
+            pass
+        self.persist_session_state_guarded()
     
     def _setup_ui(self):
         """初始化UI"""
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-        
-        # 主区域（三栏布局）- 先创建，因为工具栏需要引用这些组件
-        main_splitter = QSplitter(Qt.Orientation.Horizontal)
-        
-        # 左侧：层面板
+
+        self._graph_widget: Optional[ModelGraphWidget] = None
+        self._create_toolbar(layout)
+
+        self._workspace_splitter = QSplitter(Qt.Orientation.Horizontal)
+        self._workspace_splitter.setHandleWidth(2)
+        self._workspace_splitter.setStyleSheet(f"""
+            QSplitter::handle {{
+                background: {Styles.COLORS['surface1']};
+            }}
+        """)
+
         self._layer_palette = LayerPalette()
         self._layer_palette.setMinimumWidth(200)
         self._layer_palette.setMaximumWidth(280)
-        main_splitter.addWidget(self._layer_palette)
-        
-        # 中间：模型画布
-        self._graph_widget = ModelGraphWidget()
-        main_splitter.addWidget(self._graph_widget)
-        
-        # 右侧：属性面板
+        self._workspace_splitter.addWidget(self._layer_palette)
+
+        self._canvas_column = QWidget()
+        canvas_layout = QVBoxLayout(self._canvas_column)
+        canvas_layout.setContentsMargins(8, 8, 8, 8)
+        canvas_layout.setSpacing(0)
+        self._canvas_column.setStyleSheet(f"""
+            QWidget {{
+                background: {Styles.COLORS['mantle']};
+                border: 1px solid {Styles.COLORS['surface1']};
+            }}
+            QTabWidget, QTabBar, QWidget > QWidget {{
+                border: none;
+            }}
+        """)
+
+        self._tabs = QTabWidget()
+        self._tabs.setDocumentMode(True)
+        self._tabs.setTabsClosable(True)
+        self._tabs.setStyleSheet(Styles.canvas_tab_widget())
+        self._new_tab_button = QToolButton()
+        self._new_tab_button.setText("+")
+        self._new_tab_button.setToolTip(tr_("New model"))
+        self._new_tab_button.clicked.connect(self._on_new)
+        self._tabs.setCornerWidget(self._new_tab_button)
+        canvas_layout.addWidget(self._tabs)
+        self._workspace_splitter.addWidget(self._canvas_column)
+
         self._property_panel = LayerPropertyPanel()
         self._property_panel.setMinimumWidth(250)
         self._property_panel.setMaximumWidth(350)
-        main_splitter.addWidget(self._property_panel)
-        
-        # 设置拉伸比例
-        main_splitter.setStretchFactor(0, 0)
-        main_splitter.setStretchFactor(1, 1)
-        main_splitter.setStretchFactor(2, 0)
-        
-        # 工具栏 - 放在主区域之上
-        self._create_toolbar(layout)
-        
-        layout.addWidget(main_splitter)
+        self._workspace_splitter.addWidget(self._property_panel)
+        self._workspace_splitter.setSizes([220, 720, 300])
+        self._workspace_splitter.setStretchFactor(0, 0)
+        self._workspace_splitter.setStretchFactor(1, 1)
+        self._workspace_splitter.setStretchFactor(2, 0)
+
+        layout.addWidget(self._workspace_splitter)
     
     def _create_toolbar(self, layout):
         """创建工具栏"""
@@ -113,11 +210,11 @@ class ModelBuilderView(QWidget):
         self._toolbar.open_requested.connect(self._on_open)
         self._toolbar.save_requested.connect(self._on_save)
         self._toolbar.save_as_requested.connect(self._on_save_as)
-        self._toolbar.copy_requested.connect(self._graph_widget.copy_selected)
-        self._toolbar.delete_requested.connect(self._graph_widget.delete_selected)
+        self._toolbar.copy_requested.connect(self._copy_current_selection)
+        self._toolbar.delete_requested.connect(self._delete_current_selection)
         self._toolbar.build_requested.connect(self._on_build)
         self._toolbar.import_keras_requested.connect(self._on_import_keras)
-        self._toolbar.fit_requested.connect(self._graph_widget.fit_to_selection)
+        self._toolbar.fit_requested.connect(self._fit_current)
 
         self._model_name_label = QLabel(tr_("📐 New model"), self)
         self._model_name_label.hide()
@@ -125,23 +222,111 @@ class ModelBuilderView(QWidget):
     
     def _connect_signals(self):
         """连接信号"""
-        # 层面板信号
         self._layer_palette.layer_add_requested.connect(self._on_add_layer)
-        
-        # 画布信号
-        self._graph_widget.layer_selected.connect(self._on_layer_selected)
-        self._graph_widget.graph_changed.connect(self._on_graph_changed)
-        
-        # 属性面板信号
         self._property_panel.parameter_changed.connect(self._on_parameter_changed)
         self._property_panel.compile_config_changed.connect(self._on_compile_config_changed)
+        self._tabs.currentChanged.connect(self._on_current_tab_changed)
+        self._tabs.tabCloseRequested.connect(self._on_tab_close_requested)
     
     def _create_default_model(self):
         """创建默认模型"""
-        self._model_graph = ModelGraph("new_model")
-        self._graph_widget.set_model_graph(self._model_graph)
+        self._add_model_tab(model_graph=ModelGraph("new_model"), file_path=None, make_current=True)
         self._property_panel.set_compile_config(self._model_graph.compile_config)
         self._update_title()
+
+    def _add_model_tab(
+        self,
+        *,
+        model_graph: Optional[ModelGraph] = None,
+        file_path: Optional[str] = None,
+        source_keras_model=None,
+        make_current: bool = True,
+    ) -> int:
+        graph = model_graph or ModelGraph("new_model")
+        graph_widget = ModelGraphWidget()
+        graph_widget.set_model_graph(graph)
+        graph_widget.layer_selected.connect(self._on_layer_selected)
+        graph_widget.graph_changed.connect(self._on_graph_changed)
+
+        tab = _ModelTab(
+            graph_widget=graph_widget,
+            model_graph=graph,
+            file_path=file_path,
+            source_keras_model=source_keras_model,
+        )
+        graph_widget.setProperty("model_tab", tab)
+        idx = self._tabs.addTab(graph_widget, "")
+        self._update_tab_title(idx)
+
+        if make_current:
+            self._tabs.setCurrentIndex(idx)
+            self._sync_current_model_state()
+            self._property_panel.set_layer(None)
+            self._property_panel.set_compile_config(graph.compile_config)
+            self.model_changed.emit()
+            self.persist_session_state_guarded()
+        return idx
+
+    def _get_tab(self, index: int) -> Optional[_ModelTab]:
+        widget = self._tabs.widget(index)
+        if isinstance(widget, ModelGraphWidget):
+            tab = widget.property("model_tab")
+            if isinstance(tab, _ModelTab):
+                return tab
+        return None
+
+    def _current_tab(self) -> Optional[_ModelTab]:
+        return self._get_tab(self._tabs.currentIndex())
+
+    def _sync_current_model_state(self) -> None:
+        tab = self._current_tab()
+        if tab is None:
+            self._model_graph = None
+            self._current_file_path = None
+            self._source_keras_model = None
+            self._graph_widget = None
+            return
+
+        self._model_graph = tab.model_graph
+        self._current_file_path = tab.file_path
+        self._source_keras_model = tab.source_keras_model
+        self._graph_widget = tab.graph_widget
+
+    def _model_display_name(self, model_graph: Optional[ModelGraph], file_path: Optional[str]) -> str:
+        if file_path:
+            filename = os.path.basename(file_path)
+            return filename.replace(".model.json", "").replace(".json", "")
+        if model_graph and model_graph.name:
+            return model_graph.name
+        return "new_model"
+
+    def _tab_title_for_model(self, tab: Optional[_ModelTab]) -> str:
+        if tab is None:
+            return "new_model"
+        title = self._model_display_name(tab.model_graph, tab.file_path)
+        if getattr(tab.model_graph, "is_dirty", False):
+            return f"{title} *"
+        return title
+
+    def _update_tab_title(self, index: int) -> None:
+        if 0 <= index < self._tabs.count():
+            self._tabs.setTabText(index, self._tab_title_for_model(self._get_tab(index)))
+
+    def _refresh_all_tab_titles(self) -> None:
+        for index in range(self._tabs.count()):
+            self._update_tab_title(index)
+        self._update_title()
+
+    def _is_pristine_empty_tab(self, tab: Optional[_ModelTab]) -> bool:
+        if tab is None:
+            return False
+        graph = tab.model_graph
+        return bool(
+            not tab.file_path
+            and not getattr(graph, "is_dirty", False)
+            and not getattr(graph, "layers", {})
+            and not getattr(graph, "connections", [])
+        )
     
     def _on_add_layer(self, layer_type: str):
         """添加层"""
@@ -158,6 +343,9 @@ class ModelBuilderView(QWidget):
     
     def _on_graph_changed(self):
         """模型图变化"""
+        tab = self._current_tab()
+        if tab is not None:
+            tab.model_graph = tab.graph_widget.get_model_graph() or tab.model_graph
         self._update_title()
         self.model_changed.emit()
         self._schedule_persist_snapshot()
@@ -179,23 +367,7 @@ class ModelBuilderView(QWidget):
     
     def _on_new(self):
         """新建模型"""
-        if self._model_graph and self._model_graph.is_dirty:
-            reply = QMessageBox.question(
-                self,
-                tr_("Confirm"),
-                tr_("The current model has unsaved changes. Continue?"),
-                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No
-            )
-            if reply == QMessageBox.StandardButton.No:
-                return
-        
-        self._graph_widget.clear()
-        self._model_graph = ModelGraph("new_model")
-        self._graph_widget.set_model_graph(self._model_graph)
-        self._current_file_path = None
-        self._property_panel.set_layer(None)
-        self._property_panel.set_compile_config(self._model_graph.compile_config)
-        self._update_title()
+        self._add_model_tab(model_graph=ModelGraph("new_model"), file_path=None, make_current=True)
     
     def _on_open(self):
         """打开模型"""
@@ -208,12 +380,19 @@ class ModelBuilderView(QWidget):
         
         if file_path:
             try:
-                self._model_graph = ModelGraph.load(file_path)
-                self._graph_widget.set_model_graph(self._model_graph)
-                self._current_file_path = file_path
+                model_graph = ModelGraph.load(file_path)
+                current_tab = self._current_tab()
+                if self._is_pristine_empty_tab(current_tab) and current_tab is not None:
+                    current_tab.model_graph = model_graph
+                    current_tab.file_path = file_path
+                    current_tab.source_keras_model = None
+                    current_tab.graph_widget.set_model_graph(model_graph)
+                    self._sync_current_model_state()
+                else:
+                    self._add_model_tab(model_graph=model_graph, file_path=file_path, make_current=True)
                 self._property_panel.set_layer(None)
                 self._property_panel.set_compile_config(self._model_graph.compile_config)
-                self._update_title()
+                self._refresh_all_tab_titles()
                 logger.info(f"模型已加载: {file_path}")
 
                 try:
@@ -221,6 +400,7 @@ class ModelBuilderView(QWidget):
                     config.add_recent_file(file_path)
                 except Exception:
                     pass
+                self.persist_session_state_guarded()
             except Exception as e:
                 QMessageBox.critical(
                     self,
@@ -264,17 +444,23 @@ class ModelBuilderView(QWidget):
             
             # 解析为 ModelGraph
             parser = KerasModelParser()
-            self._model_graph = parser.parse(keras_model)
-            
-            # 保存 Keras 模型引用（用于后续可能的权重迁移）
-            self._source_keras_model = keras_model
-            
-            # 更新 UI
-            self._graph_widget.set_model_graph(self._model_graph)
-            self._current_file_path = None  # 导入的模型需要另存为
+            imported_graph = parser.parse(keras_model)
+            tab = self._current_tab()
+            if tab is None:
+                self._add_model_tab(
+                    model_graph=imported_graph,
+                    source_keras_model=keras_model,
+                    make_current=True,
+                )
+            else:
+                tab.model_graph = imported_graph
+                tab.file_path = None
+                tab.source_keras_model = keras_model
+                tab.graph_widget.set_model_graph(imported_graph)
+                self._sync_current_model_state()
             self._property_panel.set_layer(None)
             self._property_panel.set_compile_config(self._model_graph.compile_config)
-            self._update_title()
+            self._refresh_all_tab_titles()
             
             # 获取模型摘要
             summary = parser.get_model_summary(keras_model)
@@ -366,9 +552,8 @@ class ModelBuilderView(QWidget):
             file_path += '.model.json'
         
         self._save_to_path(file_path)
-        self._current_file_path = file_path
     
-    def _save_to_path(self, file_path: str):
+    def _save_to_path(self, file_path: str) -> bool:
         """保存模型到指定路径"""
         try:
             # 确保目录存在
@@ -391,7 +576,13 @@ class ModelBuilderView(QWidget):
             self._model_graph.name = sanitized_name or 'model'
             
             self._model_graph.save(file_path)
-            self._update_title()
+            tab = self._current_tab()
+            if tab is not None:
+                tab.model_graph = self._model_graph
+                tab.file_path = file_path
+                tab.source_keras_model = self._source_keras_model
+            self._current_file_path = file_path
+            self._refresh_all_tab_titles()
             self.model_saved.emit(file_path)
 
             try:
@@ -399,6 +590,7 @@ class ModelBuilderView(QWidget):
                 config.add_recent_file(file_path)
             except Exception:
                 pass
+            self.persist_session_state_guarded()
             
             QMessageBox.information(
                 self,
@@ -406,6 +598,7 @@ class ModelBuilderView(QWidget):
                 tr_("Model saved to:\n{path}").format(path=file_path),
             )
             logger.info(f"模型已保存: {file_path}")
+            return True
         except Exception as e:
             QMessageBox.critical(
                 self,
@@ -413,6 +606,7 @@ class ModelBuilderView(QWidget):
                 tr_("Failed to save model: {error}").format(error=str(e)),
             )
             logger.exception("保存模型失败")
+            return False
     
     def _on_build(self):
         """构建模型"""
@@ -491,15 +685,94 @@ class ModelBuilderView(QWidget):
         self._graph_widget.clear()
         self._model_graph = ModelGraph("new_model")
         self._graph_widget.set_model_graph(self._model_graph)
+        tab = self._current_tab()
+        if tab is not None:
+            tab.model_graph = self._model_graph
+            tab.file_path = None
+            tab.source_keras_model = None
         self._property_panel.set_layer(None)
         self._property_panel.set_compile_config(self._model_graph.compile_config)
+        self._refresh_all_tab_titles()
+
+    def _on_current_tab_changed(self, index: int):
+        self._sync_current_model_state()
+        self._property_panel.set_layer(None)
+        if self._model_graph:
+            self._property_panel.set_compile_config(self._model_graph.compile_config)
+        self._update_tab_title(index)
         self._update_title()
+        self.model_changed.emit()
+        self.persist_session_state_guarded()
+
+    def _on_tab_close_requested(self, index: int):
+        tab = self._get_tab(index)
+        if tab is None:
+            return
+
+        if tab.model_graph and getattr(tab.model_graph, "is_dirty", False):
+            name = self._model_display_name(tab.model_graph, tab.file_path)
+            msg = tr_("Save changes to '{name}' before closing?").format(name=name)
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Icon.Question)
+            box.setWindowTitle(tr_("Confirm"))
+            box.setText(msg)
+            box.setStandardButtons(
+                QMessageBox.StandardButton.Save
+                | QMessageBox.StandardButton.Discard
+                | QMessageBox.StandardButton.Cancel
+            )
+            box.setDefaultButton(QMessageBox.StandardButton.Save)
+            choice = box.exec()
+
+            if choice == QMessageBox.StandardButton.Cancel:
+                return
+            if choice == QMessageBox.StandardButton.Save:
+                self._tabs.setCurrentIndex(index)
+                if not self._save_current_tab():
+                    return
+
+        widget = tab.graph_widget
+        self._tabs.removeTab(index)
+        widget.deleteLater()
+
+        if self._tabs.count() == 0:
+            self._add_model_tab(model_graph=ModelGraph("new_model"), file_path=None, make_current=True)
+        else:
+            self._sync_current_model_state()
+            self._property_panel.set_layer(None)
+            self._refresh_all_tab_titles()
+            self.model_changed.emit()
+            self.persist_session_state_guarded()
+
+    def _copy_current_selection(self):
+        if self._graph_widget:
+            self._graph_widget.copy_selected()
+
+    def _delete_current_selection(self):
+        if self._graph_widget:
+            self._graph_widget.delete_selected()
+
+    def _fit_current(self):
+        if self._graph_widget:
+            self._graph_widget.fit_to_selection()
+
+    def _save_current_tab(self) -> bool:
+        if not self._model_graph:
+            return True
+        if self._current_file_path:
+            return self._save_to_path(self._current_file_path)
+        before = self._current_file_path
+        self._on_save_as()
+        return bool(self._current_file_path and self._current_file_path != before)
     
     def _update_title(self):
         """更新标题"""
         if self._model_graph:
             dirty_mark = " *" if self._model_graph.is_dirty else ""
             self._model_name_label.setText(f"📐 {self._model_graph.name}{dirty_mark}")
+            tab = self._current_tab()
+            if tab is not None:
+                self._update_tab_title(self._tabs.currentIndex())
 
     def _schedule_persist_snapshot(self):
         """防抖触发模型快照持久化"""

--- a/src/ui/views/workflow_tabs_view.py
+++ b/src/ui/views/workflow_tabs_view.py
@@ -2,7 +2,7 @@
 Workflow Tabs View
 
 Tab container for multiple workflow editors.
-Composes WorkflowToolbar + QTabWidget(WorkflowEditorWidget * N).
+Composes WorkflowToolbar + left/right panels + center canvas document tabs.
 """
 
 from __future__ import annotations
@@ -15,7 +15,9 @@ from PySide6.QtCore import Signal
 from PySide6.QtWidgets import (
     QFileDialog,
     QMessageBox,
+    QSplitter,
     QTabWidget,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -23,17 +25,73 @@ from PySide6.QtWidgets import (
 from src.controllers.workflow_controller import WorkflowController
 from src.core.event_bus import get_event_bus
 from src.ui.i18n import tr_
+from src.ui.node_editor import NodeGraphWidget, NodePalette, PropertyPanel
 from src.ui.styles import Styles
 from src.utils.config import config
 from src.workflow.workflow import Workflow
 
-from .workflow_editor_widget import WorkflowEditorWidget
 from .toolbars.workflow_toolbar import WorkflowToolbar
+
+
+class _WorkflowCanvasPage(QWidget):
+    """Single workflow canvas page used inside the center document tabs."""
+
+    workflow_changed = Signal()
+    node_selected = Signal(str)
+    node_double_clicked = Signal(str)
+    run_from_node_requested = Signal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self._node_graph = NodeGraphWidget()
+        layout.addWidget(self._node_graph)
+
+        self._node_graph.workflow_changed.connect(self.workflow_changed)
+        self._node_graph.node_selected.connect(self.node_selected)
+        self._node_graph.node_double_clicked.connect(self.node_double_clicked)
+        self._node_graph.run_from_node_requested.connect(self.run_from_node_requested)
+
+    def set_workflow(self, workflow: Workflow):
+        self._node_graph.set_workflow(workflow)
+
+    def get_workflow(self) -> Optional[Workflow]:
+        return self._node_graph.get_workflow()
+
+    def add_node_from_palette(self, node_type: str):
+        self._node_graph.add_node(
+            node_type,
+            self._node_graph.get_visible_viewport_center(),
+        )
+
+    def update_node_state(self, node_id: str, state: str):
+        self._node_graph.update_node_state(node_id, state)
+
+    def reset_all_node_states(self):
+        self._node_graph.reset_all_node_states()
+
+    def reset_node_states(self, node_ids: list[str]):
+        self._node_graph.reset_node_states(node_ids)
+
+    def highlight_node(self, node_id: str):
+        self._node_graph.highlight_node(node_id)
+
+    def fit_to_selection(self):
+        self._node_graph.fit_to_selection()
+
+    def copy_selected(self) -> bool:
+        return self._node_graph.copy_selected()
+
+    def delete_selected(self) -> None:
+        self._node_graph.delete_selected()
 
 
 @dataclass
 class _Tab:
-    editor: WorkflowEditorWidget
+    editor: _WorkflowCanvasPage
 
 
 @dataclass
@@ -183,6 +241,7 @@ class WorkflowTabsView(QWidget):
 
         editor.set_workflow(workflow)
         self._set_editor_session_file_path(editor, getattr(workflow, "_file_path", None))
+        self._property_panel.clear()
         self._refresh_titles()
         self.workflow_changed.emit()
 
@@ -314,6 +373,7 @@ class WorkflowTabsView(QWidget):
         if can_reuse_current and editor is not None:
             editor.set_workflow(workflow)
             self._set_editor_session_file_path(editor, path)
+            self._property_panel.clear()
             self._refresh_all_tab_titles()
             self.workflow_changed.emit()
             self.persist_session_state_guarded()
@@ -362,41 +422,62 @@ class WorkflowTabsView(QWidget):
         self._toolbar = WorkflowToolbar(show_duplicate=True)
         layout.addWidget(self._toolbar)
 
+        self._workspace_splitter = QSplitter()
+        self._workspace_splitter.setHandleWidth(2)
+        self._workspace_splitter.setStyleSheet(f"""
+            QSplitter::handle {{
+                background: {Styles.COLORS['surface1']};
+            }}
+        """)
+
+        self._node_palette = NodePalette()
+        self._node_palette.setMinimumWidth(180)
+        self._node_palette.setMaximumWidth(280)
+        self._workspace_splitter.addWidget(self._node_palette)
+
+        self._canvas_column = QWidget()
+        canvas_layout = QVBoxLayout(self._canvas_column)
+        canvas_layout.setContentsMargins(8, 8, 8, 8)
+        canvas_layout.setSpacing(0)
+        self._canvas_column.setStyleSheet(f"""
+            QWidget {{
+                background: {Styles.COLORS['mantle']};
+                border: 1px solid {Styles.COLORS['surface1']};
+            }}
+            QTabWidget, QTabBar, QWidget > QWidget {{
+                border: none;
+            }}
+        """)
+
         self._tabs = QTabWidget()
         self._tabs.setDocumentMode(True)
         self._tabs.setTabsClosable(True)
-        self._tabs.setStyleSheet(f"""
-            QTabWidget::pane {{
-                border-top: 1px solid {Styles.COLORS['surface1']};
-                background: {Styles.COLORS['base']};
-            }}
-            QTabBar::tab {{
-                background: {Styles.COLORS['surface0']};
-                color: {Styles.COLORS['text']};
-                border: 1px solid {Styles.COLORS['surface1']};
-                border-bottom: none;
-                padding: 6px 12px;
-                min-width: 96px;
-            }}
-            QTabBar::tab:selected {{
-                background: {Styles.COLORS['surface2']};
-                color: {Styles.COLORS['text']};
-            }}
-            QTabBar::tab:!selected {{
-                background: {Styles.COLORS['surface0']};
-                color: {Styles.COLORS['subtext1']};
-            }}
-            QTabBar::tab:hover {{
-                background: {Styles.COLORS['surface1']};
-                color: {Styles.COLORS['text']};
-            }}
-        """)
-        layout.addWidget(self._tabs)
+        self._tabs.setStyleSheet(Styles.canvas_tab_widget())
+        self._new_tab_button = QToolButton()
+        self._new_tab_button.setText("+")
+        self._new_tab_button.setToolTip(tr_("New workflow"))
+        self._new_tab_button.clicked.connect(self.new_tab)
+        self._tabs.setCornerWidget(self._new_tab_button)
+        canvas_layout.addWidget(self._tabs)
+        self._workspace_splitter.addWidget(self._canvas_column)
+
+        self._property_panel = PropertyPanel()
+        self._property_panel.setMinimumWidth(250)
+        self._property_panel.setMaximumWidth(350)
+        self._workspace_splitter.addWidget(self._property_panel)
+        self._workspace_splitter.setSizes([200, 700, 280])
+        self._workspace_splitter.setStretchFactor(0, 0)
+        self._workspace_splitter.setStretchFactor(1, 1)
+        self._workspace_splitter.setStretchFactor(2, 0)
+
+        layout.addWidget(self._workspace_splitter)
 
     def _connect_signals(self):
         # Tab widget signals
         self._tabs.tabCloseRequested.connect(self._on_tab_close_requested)
         self._tabs.currentChanged.connect(self._on_current_changed)
+        self._node_palette.node_add_requested.connect(self._on_add_node_from_palette)
+        self._property_panel.parameter_changed.connect(self._on_parameter_changed)
 
         # Toolbar command signals -> container logic
         self._toolbar.new_requested.connect(self.new_tab)
@@ -415,12 +496,12 @@ class WorkflowTabsView(QWidget):
     # ===== Internals =====
 
     def _add_editor_tab(self, *, workflow: Workflow, make_current: bool):
-        editor = WorkflowEditorWidget()
+        editor = _WorkflowCanvasPage()
         editor.set_workflow(workflow)
         self._set_editor_session_file_path(editor, getattr(workflow, "_file_path", None))
 
         editor.workflow_changed.connect(self._on_editor_workflow_changed)
-        editor.node_selected.connect(self.node_selected)
+        editor.node_selected.connect(self._on_node_selected)
         editor.node_double_clicked.connect(self.node_double_clicked)
         editor.run_from_node_requested.connect(self.run_from_node_requested)
 
@@ -434,15 +515,15 @@ class WorkflowTabsView(QWidget):
 
     def _get_tab(self, index: int) -> Optional[_Tab]:
         w = self._tabs.widget(index)
-        if isinstance(w, WorkflowEditorWidget):
+        if isinstance(w, _WorkflowCanvasPage):
             return _Tab(editor=w)
         return None
 
-    def _current_editor(self) -> Optional[WorkflowEditorWidget]:
+    def _current_editor(self) -> Optional[_WorkflowCanvasPage]:
         tab = self._get_tab(self._tabs.currentIndex())
         return tab.editor if tab else None
 
-    def _runtime_editor(self) -> Optional[WorkflowEditorWidget]:
+    def _runtime_editor(self) -> Optional[_WorkflowCanvasPage]:
         idx = self._running_tab_index
         if idx is not None:
             tab = self._get_tab(idx)
@@ -525,10 +606,31 @@ class WorkflowTabsView(QWidget):
 
     def _on_current_changed(self, index: int):
         self._update_tab_title(index)
+        self._property_panel.clear()
         self._refresh_titles()
         self._apply_toolbar_state_for_current_tab()
         self.workflow_changed.emit()
         self.persist_session_state_guarded()
+
+    def _on_add_node_from_palette(self, node_type: str):
+        editor = self._current_editor()
+        if editor:
+            editor.add_node_from_palette(node_type)
+
+    def _on_node_selected(self, node_id: str):
+        workflow = self.get_workflow()
+        if workflow and node_id:
+            node = workflow.get_node(node_id)
+            if node:
+                self._property_panel.set_node(node, node_id)
+                self.node_selected.emit(node_id)
+
+    def _on_parameter_changed(self, node_id: str, param_name: str, value):
+        workflow = self.get_workflow()
+        if workflow:
+            workflow._mark_dirty()
+        self._refresh_titles()
+        self.workflow_changed.emit()
 
     def _open_dialog(self):
         path, _ = QFileDialog.getOpenFileName(
@@ -552,7 +654,7 @@ class WorkflowTabsView(QWidget):
             return
         self._save_editor(editor, force_save_as=True)
 
-    def _save_editor(self, editor: WorkflowEditorWidget, *, force_save_as: bool = False) -> bool:
+    def _save_editor(self, editor: _WorkflowCanvasPage, *, force_save_as: bool = False) -> bool:
         workflow = editor.get_workflow()
         if not workflow:
             return True
@@ -642,7 +744,10 @@ class WorkflowTabsView(QWidget):
         workflow = Workflow("new_workflow")
         workflow._file_path = None  # type: ignore[attr-defined]
         editor.set_workflow(workflow)
+        self._set_editor_session_file_path(editor, None)
+        self._property_panel.clear()
         self._on_editor_workflow_changed()
+        self.persist_session_state_guarded()
 
     def _on_tab_close_requested(self, index: int):
         if self._running_tab_index is not None:
@@ -707,7 +812,7 @@ class WorkflowTabsView(QWidget):
             return p
         return None
 
-    def _set_editor_session_file_path(self, editor: WorkflowEditorWidget, file_path: object) -> None:
+    def _set_editor_session_file_path(self, editor: _WorkflowCanvasPage, file_path: object) -> None:
         """
         Persist a per-tab file path independent of Workflow internals.
 
@@ -722,7 +827,7 @@ class WorkflowTabsView(QWidget):
         except Exception:
             pass
 
-    def _get_editor_session_file_path(self, editor: WorkflowEditorWidget) -> Optional[str]:
+    def _get_editor_session_file_path(self, editor: _WorkflowCanvasPage) -> Optional[str]:
         try:
             raw = editor.property("workflow_file_path")
         except Exception:
@@ -756,8 +861,8 @@ class WorkflowTabsView(QWidget):
 
         return paths, active
 
-    def _get_dirty_editors(self) -> list[WorkflowEditorWidget]:
-        dirty: list[WorkflowEditorWidget] = []
+    def _get_dirty_editors(self) -> list[_WorkflowCanvasPage]:
+        dirty: list[_WorkflowCanvasPage] = []
         for i in range(self._tabs.count()):
             tab = self._get_tab(i)
             if not tab:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -82,6 +82,10 @@ class ConfigManager:
             'active_workflow_tab': -1,
             # 上次打开/保存的模型定义文件路径（.model.json）
             'last_model_path': None,
+            # Model definition paths reopened as tabs on startup.
+            'open_model_paths': [],
+            # Active model tab index within open_model_paths.
+            'active_model_tab': -1,
             # 模型编辑器快照（用于无可用 last_model_path 时恢复）
             'last_model_graph_snapshot': None
         }

--- a/tests/test_canvas_workspace_layout.py
+++ b/tests/test_canvas_workspace_layout.py
@@ -1,0 +1,198 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication, QMessageBox, QSplitter, QTabWidget
+
+from src.ui.model_editor.layer_palette import LayerPalette
+from src.ui.model_editor.layer_property_panel import LayerPropertyPanel
+from src.ui.node_editor import NodePalette, PropertyPanel
+from src.ui.styles import Styles
+from src.ui.views.model_builder_view import ModelBuilderView
+from src.ui.views.workflow_tabs_view import WorkflowTabsView
+from src.utils.config import config
+from src.workflow.workflow import Workflow
+
+
+def _app():
+    return QApplication.instance() or QApplication([])
+
+
+def test_canvas_tab_style_is_shared_and_uses_dark_ide_palette():
+    style = Styles.canvas_tab_widget()
+
+    assert "QTabBar::tab" in style
+    assert f"color: {Styles.COLORS['text']}" in style
+    assert f"background: {Styles.COLORS['surface2']}" in style
+    assert "background: rgba(49, 50, 68, 0.62)" in style
+    assert f"border-bottom: 2px solid {Styles.COLORS['blue']}" in style
+    assert f"border-bottom: 1px solid {Styles.COLORS['surface1']}" in style
+    assert f"border-bottom: 2px solid {Styles.COLORS['lavender']}" in style
+
+
+def test_workflow_workspace_keeps_tabs_inside_center_canvas_column():
+    _app()
+    view = WorkflowTabsView()
+
+    try:
+        assert isinstance(view._workspace_splitter, QSplitter)
+        assert isinstance(view._node_palette, NodePalette)
+        assert isinstance(view._property_panel, PropertyPanel)
+        assert isinstance(view._tabs, QTabWidget)
+
+        assert view._workspace_splitter.indexOf(view._node_palette) == 0
+        assert view._workspace_splitter.indexOf(view._canvas_column) == 1
+        assert view._workspace_splitter.indexOf(view._property_panel) == 2
+        assert view._tabs.parentWidget() is view._canvas_column
+    finally:
+        view.close()
+        _app().processEvents()
+
+
+def test_model_builder_starts_with_center_canvas_tabs_and_can_add_model_tab():
+    _app()
+    view = ModelBuilderView()
+
+    try:
+        assert isinstance(view._workspace_splitter, QSplitter)
+        assert isinstance(view._layer_palette, LayerPalette)
+        assert isinstance(view._property_panel, LayerPropertyPanel)
+        assert isinstance(view._tabs, QTabWidget)
+
+        assert view._workspace_splitter.indexOf(view._layer_palette) == 0
+        assert view._workspace_splitter.indexOf(view._canvas_column) == 1
+        assert view._workspace_splitter.indexOf(view._property_panel) == 2
+        assert view._tabs.count() == 1
+
+        first_graph = view.get_model_graph()
+        view._on_new()
+
+        assert view._tabs.count() == 2
+        assert view.get_model_graph() is not first_graph
+    finally:
+        view.close()
+        _app().processEvents()
+
+
+def test_model_builder_persists_file_backed_model_tabs(monkeypatch, tmp_path):
+    _app()
+    view = ModelBuilderView()
+    captured = {}
+
+    def capture_set(key, value):
+        captured[key] = value
+
+    first = tmp_path / "first.model.json"
+    second = tmp_path / "second.model.json"
+    first.write_text("{}", encoding="utf-8")
+    second.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(config, "set", capture_set)
+
+    try:
+        view._current_tab().file_path = str(first)
+        view._on_new()
+        view._current_tab().file_path = str(second)
+        view.persist_session_state_guarded(force=True)
+
+        assert captured["session.open_model_paths"] == [
+            str(first.resolve()),
+            str(second.resolve()),
+        ]
+        assert captured["session.active_model_tab"] == 1
+    finally:
+        view.close()
+        _app().processEvents()
+
+
+def test_model_builder_save_updates_file_backed_tab_session(monkeypatch, tmp_path):
+    _app()
+    view = ModelBuilderView()
+    captured = {}
+    target = tmp_path / "saved.model.json"
+
+    monkeypatch.setattr(config, "set", lambda key, value: captured.__setitem__(key, value))
+    monkeypatch.setattr("src.ui.views.model_builder_view.QMessageBox.information", lambda *args, **kwargs: None)
+    view.set_session_restore_in_progress(False)
+
+    try:
+        assert view._save_to_path(str(target)) is True
+        assert captured["session.open_model_paths"] == [str(target.resolve())]
+        assert captured["session.active_model_tab"] == 0
+    finally:
+        view.close()
+        _app().processEvents()
+
+
+def test_model_builder_save_failure_reports_false(monkeypatch, tmp_path):
+    _app()
+    view = ModelBuilderView()
+
+    def fail_save(_path):
+        raise OSError("cannot save")
+
+    monkeypatch.setattr(view.get_model_graph(), "save", fail_save)
+    monkeypatch.setattr("src.ui.views.model_builder_view.QMessageBox.critical", lambda *args, **kwargs: None)
+
+    try:
+        assert view._save_to_path(str(tmp_path / "broken.model.json")) is False
+    finally:
+        view.close()
+        _app().processEvents()
+
+
+def test_workflow_replacing_workflow_clears_shared_property_panel():
+    _app()
+    view = WorkflowTabsView()
+    view._property_panel._current_node = object()
+    view._property_panel._current_node_id = "stale"
+
+    try:
+        view.set_workflow(Workflow("replacement"))
+
+        assert view._property_panel._current_node is None
+        assert view._property_panel._current_node_id is None
+    finally:
+        view.close()
+        _app().processEvents()
+
+
+def test_workflow_parameter_change_refreshes_dirty_tab_title():
+    _app()
+    view = WorkflowTabsView()
+
+    try:
+        assert not view._tabs.tabText(view._tabs.currentIndex()).endswith("*")
+
+        view._on_parameter_changed("missing", "value", 1)
+
+        assert view._tabs.tabText(view._tabs.currentIndex()).endswith("*")
+    finally:
+        view.close()
+        _app().processEvents()
+
+
+def test_workflow_clear_current_drops_file_backed_session_path(monkeypatch, tmp_path):
+    _app()
+    view = WorkflowTabsView()
+    captured = {}
+    workflow_path = tmp_path / "old_workflow.json"
+    workflow_path.write_text("{}", encoding="utf-8")
+    editor = view._current_editor()
+
+    monkeypatch.setattr(
+        "src.ui.views.workflow_tabs_view.QMessageBox.question",
+        lambda *args, **kwargs: QMessageBox.StandardButton.Yes,
+    )
+    monkeypatch.setattr(config, "set", lambda key, value: captured.__setitem__(key, value))
+
+    try:
+        view._set_editor_session_file_path(editor, str(workflow_path))
+        view._clear_current()
+        view.persist_session_state_guarded(force=True)
+
+        assert captured["session.open_workflow_paths"] == []
+        assert captured["session.active_workflow_tab"] == -1
+    finally:
+        view.close()
+        _app().processEvents()

--- a/tests/test_workflow_tabs_style.py
+++ b/tests/test_workflow_tabs_style.py
@@ -17,8 +17,10 @@ def test_workflow_tab_bar_styles_keep_inactive_tab_text_readable():
 
         assert "QTabBar::tab" in style
         assert f"color: {Styles.COLORS['text']}" in style
-        assert f"background: {Styles.COLORS['surface0']}" in style
         assert f"background: {Styles.COLORS['surface2']}" in style
+        assert "background: rgba(49, 50, 68, 0.62)" in style
+        assert f"border-bottom: 2px solid {Styles.COLORS['blue']}" in style
+        assert f"border-bottom: 1px solid {Styles.COLORS['surface1']}" in style
     finally:
         view.close()
         app.processEvents()


### PR DESCRIPTION
## Summary
- Move workflow document tabs into the center canvas column while keeping the left node library and right property panel outside the tab area.
- Add real multi-model tabs to the model builder with active-tab command routing and file-backed session restore.
- Share dark IDE-style canvas tab styling across workflow/model workspaces and add regression coverage.

## Related Issue
Closes #92

## Test Plan
- [x] `.\.venv\Scripts\python.exe -m pytest -q` (`52 passed`)
- [x] `git diff --cached --check`
- [x] Focused canvas tab style/layout tests pass

## Notes
- Excluded local `.cursor/skills/project_managing_i18n/`, audio data, and model artifacts from the commit.