### PR TITLE
feat(ui): recalibrate canvas fit origin

### DIFF
--- a/src/ui/graph_editor/base_items.py
+++ b/src/ui/graph_editor/base_items.py
@@ -6,7 +6,7 @@ Provides reusable graphics item base classes for node_editor and model_editor.
 """
 
 import logging
-from typing import List, Optional
+from typing import Iterable, List, Optional
 
 from PySide6.QtCore import QPoint, QPointF, QRectF, Qt
 from PySide6.QtGui import (
@@ -437,6 +437,30 @@ class BaseGraphView(QGraphicsView):
         # 平移状态
         self._is_panning = False
         self._last_pan_pos = QPoint()
+
+    def fit_items_to_origin(self, movable_items: Iterable[QGraphicsItem]):
+        """Fit graph content and rebase movable items so the content center is the origin."""
+        items = list(movable_items)
+        if not items:
+            self.resetTransform()
+            self.centerOn(0, 0)
+            return
+
+        scene = self.scene()
+        content_rect = scene.itemsBoundingRect()
+        if content_rect.isNull() or content_rect.isEmpty():
+            self.resetTransform()
+            self.centerOn(0, 0)
+            return
+
+        offset = content_rect.center()
+        for item in items:
+            item.setPos(item.pos() - offset)
+
+        rebased_rect = scene.itemsBoundingRect()
+        self.resetTransform()
+        self.fitInView(rebased_rect, Qt.AspectRatioMode.KeepAspectRatio)
+        self.centerOn(0, 0)
     
     def wheelEvent(self, event: QWheelEvent):
         """鼠标滚轮缩放"""

--- a/src/ui/model_editor/model_graph_widget.py
+++ b/src/ui/model_editor/model_graph_widget.py
@@ -15,7 +15,7 @@ Canvas for visually editing neural network structure.
 import logging
 from typing import Dict, List, Optional
 
-from PySide6.QtCore import QPoint, QPointF, QRectF, Qt, Signal
+from PySide6.QtCore import QPoint, QPointF, QRectF, Qt, QTimer, Signal
 from PySide6.QtGui import (
     QBrush, QColor, QDragEnterEvent, QDropEvent, QFont,
     QKeyEvent, QMouseEvent, QPainter, QPainterPath, QPen, QWheelEvent
@@ -372,6 +372,9 @@ class ModelGraphWidget(QWidget):
     
     CLIPBOARD_KIND = "model_layers"
     PASTE_OFFSET = (40.0, 40.0)
+    AUTO_FIT_RETRY_MS = 50
+    MIN_AUTO_FIT_VIEWPORT_WIDTH = 160
+    MIN_AUTO_FIT_VIEWPORT_HEIGHT = 120
 
     layer_selected = Signal(str)
     layer_double_clicked = Signal(str)
@@ -383,6 +386,10 @@ class ModelGraphWidget(QWidget):
         
         self.model_graph: Optional[ModelGraph] = None
         self._paste_serial = 0
+        self._initial_fit_pending = False
+        self._initial_fit_timer = QTimer(self)
+        self._initial_fit_timer.setSingleShot(True)
+        self._initial_fit_timer.timeout.connect(self._run_initial_fit_when_ready)
         
         self._setup_ui()
         self._connect_signals()
@@ -410,6 +417,47 @@ class ModelGraphWidget(QWidget):
         """设置模型图"""
         self.model_graph = graph
         self._sync_from_graph()
+        self._request_initial_fit()
+
+    def showEvent(self, event):
+        """Run pending startup fit after the canvas becomes visible."""
+        super().showEvent(event)
+        self._schedule_initial_fit_if_pending()
+
+    def resizeEvent(self, event):
+        """Retry pending startup fit once layout gives the canvas a real size."""
+        super().resizeEvent(event)
+        self._schedule_initial_fit_if_pending()
+
+    def _request_initial_fit(self):
+        """Schedule initial fit without using an undersized hidden viewport."""
+        self._initial_fit_pending = True
+        self._schedule_initial_fit_if_pending()
+
+    def _schedule_initial_fit_if_pending(self):
+        if self._initial_fit_pending and not self._initial_fit_timer.isActive():
+            self._initial_fit_timer.start(0)
+
+    def _is_initial_fit_viewport_ready(self) -> bool:
+        size = self._view.viewport().size()
+        return (
+            self.isVisible()
+            and self._view.isVisible()
+            and size.width() >= self.MIN_AUTO_FIT_VIEWPORT_WIDTH
+            and size.height() >= self.MIN_AUTO_FIT_VIEWPORT_HEIGHT
+        )
+
+    def _run_initial_fit_when_ready(self):
+        if not self._initial_fit_pending:
+            return
+
+        if self._is_initial_fit_viewport_ready():
+            self._initial_fit_pending = False
+            self.fit_to_selection()
+            return
+
+        if self.isVisible():
+            self._initial_fit_timer.start(self.AUTO_FIT_RETRY_MS)
     
     def get_model_graph(self) -> Optional[ModelGraph]:
         """获取模型图"""
@@ -692,8 +740,8 @@ class ModelGraphWidget(QWidget):
         self.model_graph = None
     
     def fit_to_selection(self):
-        """适应选中内容"""
-        self._view.fitInView(self._scene.itemsBoundingRect(), Qt.AspectRatioMode.KeepAspectRatio)
+        """Fit graph content and recalibrate the canvas origin."""
+        self._view.fit_items_to_origin(self._scene.layer_items.values())
     
     def center_on(self, layer_id: str):
         """居中显示指定层"""

--- a/src/ui/node_editor/node_graph.py
+++ b/src/ui/node_editor/node_graph.py
@@ -15,7 +15,7 @@ Node editing canvas implemented with pure PySide6.
 import logging
 from typing import Dict, List, Optional, Tuple
 
-from PySide6.QtCore import QPoint, QPointF, QRectF, Qt, Signal
+from PySide6.QtCore import QPoint, QPointF, QRectF, Qt, QTimer, Signal
 from PySide6.QtGui import (
     QAction, QBrush, QColor, QDragEnterEvent, QDropEvent,
     QFont, QKeyEvent, QMouseEvent, QPainter, QPainterPath, QPen, QWheelEvent
@@ -550,6 +550,9 @@ class NodeGraphWidget(QWidget):
     
     CLIPBOARD_KIND = "workflow_nodes"
     PASTE_OFFSET = (40.0, 40.0)
+    AUTO_FIT_RETRY_MS = 50
+    MIN_AUTO_FIT_VIEWPORT_WIDTH = 160
+    MIN_AUTO_FIT_VIEWPORT_HEIGHT = 120
 
     node_selected = Signal(str)
     node_double_clicked = Signal(str)
@@ -562,6 +565,10 @@ class NodeGraphWidget(QWidget):
         
         self.workflow: Optional[Workflow] = None
         self._paste_serial = 0
+        self._initial_fit_pending = False
+        self._initial_fit_timer = QTimer(self)
+        self._initial_fit_timer.setSingleShot(True)
+        self._initial_fit_timer.timeout.connect(self._run_initial_fit_when_ready)
         
         self._setup_ui()
         self._connect_signals()
@@ -591,6 +598,47 @@ class NodeGraphWidget(QWidget):
         """设置工作流"""
         self.workflow = workflow
         self._sync_from_workflow()
+        self._request_initial_fit()
+
+    def showEvent(self, event):
+        """Run pending startup fit after the canvas becomes visible."""
+        super().showEvent(event)
+        self._schedule_initial_fit_if_pending()
+
+    def resizeEvent(self, event):
+        """Retry pending startup fit once layout gives the canvas a real size."""
+        super().resizeEvent(event)
+        self._schedule_initial_fit_if_pending()
+
+    def _request_initial_fit(self):
+        """Schedule initial fit without using an undersized hidden viewport."""
+        self._initial_fit_pending = True
+        self._schedule_initial_fit_if_pending()
+
+    def _schedule_initial_fit_if_pending(self):
+        if self._initial_fit_pending and not self._initial_fit_timer.isActive():
+            self._initial_fit_timer.start(0)
+
+    def _is_initial_fit_viewport_ready(self) -> bool:
+        size = self._view.viewport().size()
+        return (
+            self.isVisible()
+            and self._view.isVisible()
+            and size.width() >= self.MIN_AUTO_FIT_VIEWPORT_WIDTH
+            and size.height() >= self.MIN_AUTO_FIT_VIEWPORT_HEIGHT
+        )
+
+    def _run_initial_fit_when_ready(self):
+        if not self._initial_fit_pending:
+            return
+
+        if self._is_initial_fit_viewport_ready():
+            self._initial_fit_pending = False
+            self.fit_to_selection()
+            return
+
+        if self.isVisible():
+            self._initial_fit_timer.start(self.AUTO_FIT_RETRY_MS)
     
     def get_workflow(self) -> Optional[Workflow]:
         """获取工作流"""
@@ -910,8 +958,8 @@ class NodeGraphWidget(QWidget):
         self.workflow = None
     
     def fit_to_selection(self):
-        """适应选中内容"""
-        self._view.fitInView(self._scene.itemsBoundingRect(), Qt.AspectRatioMode.KeepAspectRatio)
+        """Fit graph content and recalibrate the canvas origin."""
+        self._view.fit_items_to_origin(self._scene.node_items.values())
     
     def center_on(self, node_id: str):
         """居中显示指定节点"""

--- a/tests/test_canvas_fit_origin.py
+++ b/tests/test_canvas_fit_origin.py
@@ -1,0 +1,207 @@
+import os
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication
+from PySide6.QtTest import QTest
+
+from src.model_builder.model_graph import ModelGraph
+from src.ui.views.model_builder_view import ModelBuilderView
+from src.ui.views.workflow_editor_widget import WorkflowEditorWidget
+from src.workflow import Workflow
+
+
+class CanvasFitOriginTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_workflow_fit_recenters_content_coordinates_around_origin(self):
+        widget = WorkflowEditorWidget()
+        self.addCleanup(widget.close)
+        widget.resize(900, 600)
+        widget.show()
+
+        workflow = Workflow("fit_origin_workflow")
+        widget.set_workflow(workflow)
+        node_graph = widget._node_graph
+
+        source_id = node_graph.add_node("audio_file", (2400.0, -1200.0))
+        sink_id = node_graph.add_node("fft", (2750.0, -960.0))
+        self.assertIsNotNone(source_id)
+        self.assertIsNotNone(sink_id)
+
+        before_dx = workflow.get_node(sink_id).position[0] - workflow.get_node(source_id).position[0]
+        before_dy = workflow.get_node(sink_id).position[1] - workflow.get_node(source_id).position[1]
+
+        node_graph.fit_to_selection()
+        self.app.processEvents()
+
+        after_center = node_graph._scene.itemsBoundingRect().center()
+        viewport_center = node_graph._view.mapToScene(node_graph._view.viewport().rect().center())
+
+        self.assertAlmostEqual(after_center.x(), 0.0, delta=2.0)
+        self.assertAlmostEqual(after_center.y(), 0.0, delta=2.0)
+        self.assertAlmostEqual(viewport_center.x(), 0.0, delta=3.0)
+        self.assertAlmostEqual(viewport_center.y(), 0.0, delta=3.0)
+        self.assertAlmostEqual(
+            workflow.get_node(sink_id).position[0] - workflow.get_node(source_id).position[0],
+            before_dx,
+            delta=0.01,
+        )
+        self.assertAlmostEqual(
+            workflow.get_node(sink_id).position[1] - workflow.get_node(source_id).position[1],
+            before_dy,
+            delta=0.01,
+        )
+
+    def test_model_fit_recenters_content_coordinates_around_origin(self):
+        widget = ModelBuilderView()
+        self.addCleanup(widget.close)
+        widget.resize(900, 600)
+        widget.show()
+
+        graph_widget = widget._graph_widget
+        model_graph = widget.get_model_graph()
+
+        input_id = graph_widget.add_layer("input", (-3100.0, 1800.0))
+        output_id = graph_widget.add_layer("output", (-2800.0, 1960.0))
+        self.assertIsNotNone(input_id)
+        self.assertIsNotNone(output_id)
+
+        before_dx = model_graph.get_layer(output_id).position[0] - model_graph.get_layer(input_id).position[0]
+        before_dy = model_graph.get_layer(output_id).position[1] - model_graph.get_layer(input_id).position[1]
+
+        graph_widget.fit_to_selection()
+        self.app.processEvents()
+
+        after_center = graph_widget._scene.itemsBoundingRect().center()
+        viewport_center = graph_widget._view.mapToScene(graph_widget._view.viewport().rect().center())
+
+        self.assertAlmostEqual(after_center.x(), 0.0, delta=2.0)
+        self.assertAlmostEqual(after_center.y(), 0.0, delta=2.0)
+        self.assertAlmostEqual(viewport_center.x(), 0.0, delta=3.0)
+        self.assertAlmostEqual(viewport_center.y(), 0.0, delta=3.0)
+        self.assertAlmostEqual(
+            model_graph.get_layer(output_id).position[0] - model_graph.get_layer(input_id).position[0],
+            before_dx,
+            delta=0.01,
+        )
+        self.assertAlmostEqual(
+            model_graph.get_layer(output_id).position[1] - model_graph.get_layer(input_id).position[1],
+            before_dy,
+            delta=0.01,
+        )
+
+    def test_empty_workflow_fit_restores_default_origin(self):
+        widget = WorkflowEditorWidget()
+        self.addCleanup(widget.close)
+        widget.resize(900, 600)
+        widget.show()
+
+        workflow = Workflow("empty_fit_origin_workflow")
+        widget.set_workflow(workflow)
+        node_graph = widget._node_graph
+        node_graph._view.scale(1.5, 1.5)
+        node_graph._view.centerOn(1800.0, -900.0)
+
+        node_graph.fit_to_selection()
+        self.app.processEvents()
+
+        viewport_center = node_graph._view.mapToScene(node_graph._view.viewport().rect().center())
+        self.assertAlmostEqual(viewport_center.x(), 0.0, delta=2.0)
+        self.assertAlmostEqual(viewport_center.y(), 0.0, delta=2.0)
+        self.assertAlmostEqual(node_graph._view.transform().m11(), 1.0, delta=0.01)
+
+    def test_workflow_canvas_auto_fits_after_initial_workflow_load(self):
+        widget = WorkflowEditorWidget()
+        self.addCleanup(widget.close)
+        widget.resize(900, 600)
+        widget.show()
+
+        workflow = Workflow("startup_fit_workflow")
+        workflow.create_and_add_node("audio_file", (2200.0, 1400.0))
+        workflow.create_and_add_node("fft", (2500.0, 1600.0))
+
+        widget.set_workflow(workflow)
+        self.app.processEvents()
+
+        node_graph = widget._node_graph
+        after_center = node_graph._scene.itemsBoundingRect().center()
+        viewport_center = node_graph._view.mapToScene(node_graph._view.viewport().rect().center())
+
+        self.assertAlmostEqual(after_center.x(), 0.0, delta=2.0)
+        self.assertAlmostEqual(after_center.y(), 0.0, delta=2.0)
+        self.assertAlmostEqual(viewport_center.x(), 0.0, delta=3.0)
+        self.assertAlmostEqual(viewport_center.y(), 0.0, delta=3.0)
+
+    def test_model_canvas_auto_fits_after_initial_graph_load(self):
+        widget = ModelBuilderView()
+        self.addCleanup(widget.close)
+        widget.resize(900, 600)
+        widget.show()
+
+        model_graph = ModelGraph("startup_fit_model")
+        model_graph.create_and_add_layer("input", (-2500.0, -1500.0))
+        model_graph.create_and_add_layer("output", (-2200.0, -1360.0))
+
+        widget.set_model_graph(model_graph)
+        self.app.processEvents()
+
+        graph_widget = widget._graph_widget
+        after_center = graph_widget._scene.itemsBoundingRect().center()
+        viewport_center = graph_widget._view.mapToScene(graph_widget._view.viewport().rect().center())
+
+        self.assertAlmostEqual(after_center.x(), 0.0, delta=2.0)
+        self.assertAlmostEqual(after_center.y(), 0.0, delta=2.0)
+        self.assertAlmostEqual(viewport_center.x(), 0.0, delta=3.0)
+        self.assertAlmostEqual(viewport_center.y(), 0.0, delta=3.0)
+
+    def test_workflow_auto_fit_waits_until_canvas_is_visible_and_sized(self):
+        widget = WorkflowEditorWidget()
+        self.addCleanup(widget.close)
+
+        workflow = Workflow("hidden_startup_fit_workflow")
+        workflow.create_and_add_node("audio_file", (-700.0, -300.0))
+        workflow.create_and_add_node("fft", (500.0, 200.0))
+
+        widget.set_workflow(workflow)
+        self.app.processEvents()
+
+        widget.resize(900, 600)
+        widget.show()
+        QTest.qWait(80)
+
+        node_graph = widget._node_graph
+        viewport_center = node_graph._view.mapToScene(node_graph._view.viewport().rect().center())
+
+        self.assertGreater(node_graph._view.transform().m11(), 0.2)
+        self.assertAlmostEqual(viewport_center.x(), 0.0, delta=5.0)
+        self.assertAlmostEqual(viewport_center.y(), 0.0, delta=5.0)
+
+    def test_model_auto_fit_waits_until_canvas_is_visible_and_sized(self):
+        widget = ModelBuilderView()
+        self.addCleanup(widget.close)
+
+        model_graph = ModelGraph("hidden_startup_fit_model")
+        model_graph.create_and_add_layer("input", (-700.0, -300.0))
+        model_graph.create_and_add_layer("output", (500.0, 200.0))
+
+        widget.set_model_graph(model_graph)
+        self.app.processEvents()
+
+        widget.resize(900, 600)
+        widget.show()
+        QTest.qWait(80)
+
+        graph_widget = widget._graph_widget
+        viewport_center = graph_widget._view.mapToScene(graph_widget._view.viewport().rect().center())
+
+        self.assertGreater(graph_widget._view.transform().m11(), 0.2)
+        self.assertAlmostEqual(viewport_center.x(), 0.0, delta=5.0)
+        self.assertAlmostEqual(viewport_center.y(), 0.0, delta=5.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Recalibrate Workflow and Model canvas content around the origin whenever Fit runs.
- Auto-fit canvases after startup/session graph loading, but defer the fit until the viewport is visible and has a real size.
- Add regression coverage for manual Fit, empty canvases, startup auto-fit, and hidden-before-show canvas loading.

## Related Issue
Closes #98

## Test Plan
- [x] `.\.venv\Scripts\python.exe -m pytest tests/test_canvas_fit_origin.py tests/test_double_click_center_placement.py tests/test_graph_copy_paste.py`
- [x] IDE lints for changed files: no errors
- [ ] Full `pytest` after the final viewport-timing fix was started but interrupted before completion

## Notes
The final fix addresses the observed startup shrink issue by avoiding Fit calculations while the canvas viewport is still the tiny pre-layout size.