### PR TITLE
docs(cursor): refresh rules documentation

### DIFF
--- a/.cursor/rules/architecture.md
+++ b/.cursor/rules/architecture.md
@@ -9,9 +9,10 @@
 | Language | Python 3.10+ |
 | GUI Framework | PySide6 (Catppuccin dark theme) |
 | Node Editor | Custom PySide6 implementation |
-| Deep Learning | TensorFlow 2.15+ / Keras 3.0+ |
-| Audio Processing | librosa, soundfile, scipy, pydub, sounddevice |
+| Deep Learning | TensorFlow 2.17+ / Keras |
+| Audio Processing | librosa, soundfile, scipy, resampy, sounddevice |
 | Visualization | pyqtgraph, matplotlib |
+| i18n | gettext catalogs under `src/locale/` |
 
 ## Core Concepts
 
@@ -49,11 +50,11 @@ The platform uses a **node-based workflow** architecture, where users define com
 
 ```
 DT_playground/
-├── main.py                     # Application entry (logging config, Qt init, global exception handling)
+├── main.py                     # Application entry (logging, Qt init, splash, i18n bootstrap, restart handshake)
 ├── requirements.txt            # Dependency list
 ├── .cursor/
-│   ├── rules.mdc              # Cursor AI rules entry point
 │   ├── rules/                 # Rule documents
+│   │   ├── rules.mdc          # Cursor AI rules entry point
 │   │   ├── architecture.md    # This file
 │   │   ├── coding_standards.md # Coding standards
 │   │   └── model_json_spec.md # Model JSON specification
@@ -66,9 +67,8 @@ DT_playground/
 ├── models/                     # Saved trained models
 ├── resources/
 │   └── styles/
-│       └── dark_theme.qss     # QSS stylesheet
-├── tests/
-│   └── __init__.py
+│       └── dark_theme.qss     # Legacy/optional QSS stylesheet; runtime styles are mostly programmatic
+├── tests/                      # Automated tests (pytest and unittest style)
 └── src/                        # Source code
     ├── __init__.py
     ├── app.py                  # AudioTrainingApp main application class
@@ -83,7 +83,9 @@ DT_playground/
     │   ├── __init__.py
     │   ├── workflow_controller.py   # WorkflowController (manages Engine lifecycle)
     │   ├── training_controller.py   # TrainingController
-    │   └── navigation_controller.py # NavigationController (view navigation)
+    │   ├── navigation_controller.py # NavigationController (view navigation)
+    │   ├── navigation_dto.py        # Navigation DTOs
+    │   └── view_types.py            # View type enum/constants
     │
     ├── workflow/               # Workflow engine
     │   ├── __init__.py
@@ -97,7 +99,11 @@ DT_playground/
     │       ├── data_source.py      # Data source nodes
     │       ├── preprocessing.py    # Preprocessing nodes
     │       ├── augmentation.py     # Data augmentation nodes
-    │       ├── feature.py          # Feature extraction nodes
+    │       ├── feature/            # Feature extraction node package
+    │       │   ├── base.py         # FeatureData and feature helpers
+    │       │   ├── ai_embedding.py # AI feature extraction node
+    │       │   ├── dim1d/          # 1D feature nodes
+    │       │   └── dim2d/          # 2D feature nodes
     │       ├── training.py         # Training nodes
     │       └── control.py          # Control nodes
     │
@@ -139,19 +145,28 @@ DT_playground/
     │
     ├── ui/                     # UI module
     │   ├── __init__.py
-    │   ├── main_window.py      # MainWindow
+    │   ├── main_window.py      # Embedded main content widget
     │   ├── styles.py           # Styles unified style management
+    │   ├── i18n.py             # gettext helpers
+    │   ├── startup_splash.py   # Startup splash and app icon path helpers
+    │   ├── title_bar.py        # Custom frameless title bar
     │   │
     │   ├── views/              # View module
     │   │   ├── __init__.py
     │   │   ├── workflow_view.py
+    │   │   ├── workflow_tabs_view.py
+    │   │   ├── workflow_editor_widget.py
     │   │   ├── model_builder_view.py
     │   │   ├── preview_view.py
-    │   │   └── training_view.py
+    │   │   ├── training_view.py
+    │   │   └── toolbars/
+    │   │       ├── workflow_toolbar.py
+    │   │       └── model_toolbar.py
     │   │
     │   ├── graph_editor/       # Graph editor base classes
     │   │   ├── __init__.py
-    │   │   └── base_items.py
+    │   │   ├── base_items.py
+    │   │   └── clipboard.py
     │   │
     │   ├── node_editor/        # Node editor components
     │   │   ├── __init__.py
@@ -167,9 +182,12 @@ DT_playground/
     │   │
     │   ├── widgets/            # Custom widgets
     │   │   ├── __init__.py
+    │   │   ├── command_toolbar.py
+    │   │   ├── command_toolbar_spec.py
     │   │   ├── waveform_widget.py
     │   │   ├── spectrogram_widget.py
-    │   │   └── audio_player.py
+    │   │   ├── audio_player.py
+    │   │   └── preview/        # Preview widgets for audio/features/model/metrics/labels
     │   │
     │   └── dialogs/            # Dialogs
     │       ├── __init__.py
@@ -184,12 +202,24 @@ DT_playground/
     │   ├── spectrogram.py
     │   └── metrics.py
     │
+    ├── services/               # Application services
+    │   ├── __init__.py
+    │   ├── system_info_service.py
+    │   └── training_params_service.py
+    │
+    ├── locale/                 # gettext catalogs
+    │   ├── messages.pot
+    │   ├── en_US/LC_MESSAGES/messages.po
+    │   └── zh_CN/LC_MESSAGES/messages.po
+    │
     └── utils/                  # Utility module
         ├── __init__.py
-        ├── config.py           # ConfigManager singleton
+        ├── config.py           # ConfigManager singleton and module-level config
         ├── dataset_manager.py  # DatasetManager
         ├── audio_utils.py
+        ├── dialogs.py
         ├── file_utils.py
+        ├── restart_manager.py
         └── pyqtgraph_fix.py
 ```
 
@@ -215,6 +245,7 @@ DT_playground/
 ┌─────────────────────────▼───────────────────────────────────┐
 │                    Service/Engine Layer                      │
 │  src/workflow/engine.py    src/training/trainer.py          │
+│  src/services/                                                │
 └─────────────────────────┬───────────────────────────────────┘
                           │
 ┌─────────────────────────▼───────────────────────────────────┐
@@ -311,9 +342,8 @@ class ConfigManager:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-# Get config (recommend using function instead of direct instance access)
-def get_config() -> ConfigManager:
-    return ConfigManager()
+# Module-level singleton used by application code
+config = ConfigManager()
 ```
 
 #### 6. Composite Pattern
@@ -521,6 +551,7 @@ class DataType(Enum):
 | 📂 AudioFolderNode | audio | Load all audio in directory (List[AudioData]) |
 | 📄 LabelFileNode | labels | Load CSV/JSON label file |
 | 🎵 AudioFileNode | audio | Load single audio file (AudioData) |
+| 💾 SaveAudioNode | audio | Save audio data to disk |
 
 #### Preprocessing Nodes (Preprocessing)
 | Node | Input | Output | Parameters |
@@ -528,16 +559,23 @@ class DataType(Enum):
 | 📏 ResampleNode | audio | audio | target_sr |
 | ✂️ TrimPadNode | audio | audio | duration, mode |
 | 📊 NormalizeNode | audio | audio | method (peak/rms) |
+| 🪟 WindowingNode | audio | audio | window_size, hop_size |
+| 🧹 SpectralSubtractionNode | audio | audio | noise reduction parameters |
 | 🎚️ SilenceTrimNode | audio | audio | threshold_db |
+| 🔀 ChannelMapperNode | audio | audio | channel mapping |
+| 🔗 ChannelMergeNode | audio | audio | merge method |
+| 🎛️ FilterNode | audio | audio | filter type and cutoff |
 
 #### Data Augmentation Nodes (Augmentation)
 | Node | Input | Output | Parameters |
 |------|-------|--------|------------|
 | 🔊 AddNoiseNode | audio | audio | noise_type, snr_db |
+| 📈 SampleExpansionNode | audio | audio | expansion strategy |
+| 🔉 AdjustGainNode | audio | audio | gain_db |
 | ⏱️ TimeStretchNode | audio | audio | rate_range |
 | 🎵 PitchShiftNode | audio | audio | semitones_range |
 | 🏛️ ReverbNode | audio, ir(optional) | audio | decay, wet_mix, random_wet_mix |
-| 🔀 RandomAugmentNode | audio | audio | augmentations[] |
+| ✂️ AudioSliceNode | audio | audio | slice duration/overlap |
 
 #### Feature Extraction Nodes (Feature)
 | Node | Input | Output | Parameters |
@@ -545,7 +583,13 @@ class DataType(Enum):
 | 📈 MelSpectrogramNode | audio | feature_2d | n_mels, hop_length |
 | 📊 MFCCNode | audio | feature_2d | n_mfcc, include_delta |
 | 🎼 STFTNode | audio | feature_2d | n_fft, hop_length |
+| 🎹 CQTNode | audio | feature_2d | bins_per_octave, n_bins |
+| 🌈 SpectralContrastNode | audio | feature_2d | n_bands |
 | 📉 StatisticsNode | audio | feature_1d | features[] |
+| 📊 FFTNode | audio | feature_1d | n_fft |
+| 🎵 PitchNode | audio | feature_1d | method |
+| 📐 SpectralFlatnessNode | audio | feature_1d | n_fft, hop_length |
+| 🤖 AIFeatureExtractionNode | audio | feature | embedding/model options |
 
 #### Training Nodes (Training)
 | Node | Input Ports | Output Ports | Description |
@@ -554,6 +598,9 @@ class DataType(Enum):
 | 📤 SaveModelNode | model | model_path | Save model |
 | 🏋️ TrainerNode | input, target, model | trained_model | Execute training |
 | 📊 EvaluatorNode | model, data | metrics | Evaluate model |
+| 📈 ShowHistoryNode | history | preview | Visualize training curves |
+| 📋 ShowMetricsNode | metrics | preview | Display evaluation metrics |
+| 🔮 PredictNode | model, data | predictions | Run prediction |
 
 #### Control Nodes (Control)
 | Node | Input | Output | Description |
@@ -561,6 +608,9 @@ class DataType(Enum):
 | ◇ PassthroughNode | in | out | Passthrough node |
 | 🔄 LoopNode | data | item | Loop over dataset |
 | ✂️ SplitNode | data | train, val, test | Dataset split |
+| 🔗 MergeNode | inputs | data | Merge streams |
+| ⏸ BreakpointNode | data | data | Pause workflow execution |
+| ✅ ValidateShapeNode | data | data | Validate tensor/audio shape |
 
 ### Unified Parameter Class
 
@@ -584,7 +634,8 @@ class Parameter:
     """Unified parameter definition"""
     name: str
     param_type: ParamType
-    default: Any
+    default_value: Any
+    display_name: str = ""
     description: str = ""
     min_value: Optional[float] = None
     max_value: Optional[float] = None
@@ -626,9 +677,9 @@ class BaseNode:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Menu Bar  │  File  │  Edit  │  View  │  Workflow  │  Help  │    │
+│  Custom Title Bar / App Shell (AudioTrainingApp)                 │
 ├─────────────────────────────────────────────────────────────────┤
-│  Toolbar  │ New │ Open │ Save │ ─── │ Run │ Stop │ ─── │ View Switch │
+│  Grouped Toolbars: workflow and model actions                    │
 ├──────────┬──────────────────────────────────────────┬───────────┤
 │          │                                          │           │
 │  Node    │           Main View Area                 │  Property │
@@ -649,13 +700,18 @@ class BaseNode:
 └──────────┴──────────────────────────────────────────┴───────────┘
 ```
 
+`AudioTrainingApp` (`src/app.py`) is the frameless `QMainWindow` shell. `MainWindow`
+(`src/ui/main_window.py`) is the embedded content widget. Workflow editing is routed
+through `WorkflowTabsView`, with each tab backed by a `WorkflowEditorWidget`.
+
 ### View Descriptions
 
 | View | Components | Function |
 |------|------------|----------|
-| WorkflowView | NodeGraph + Nodes | Drag-and-drop workflow editing |
+| WorkflowTabsView | WorkflowEditorWidget + tabs | Multi-tab workflow editing |
+| WorkflowView | WorkflowEditorWidget wrapper | Single workflow editing surface |
 | ModelBuilderView | ModelGraph + Layer Nodes | Visual drag-and-drop neural network building |
-| PreviewView | WaveformWidget + SpectrogramWidget | Preview audio/feature data |
+| PreviewView | Preview widgets | Preview audio, features, model data, metrics, and labels |
 | TrainingView | TrainingPanel + MetricsChart | Training progress and metrics monitoring |
 
 ### Graph Editor Base Classes
@@ -672,12 +728,28 @@ The workflow editor and model editor share common graph editing UI base classes 
 
 **Reusable Features**:
 - Node/port rendering and interaction
-- Connection line drawing (Bezier curves)
+- Connection line drawing (rounded orthogonal segments)
 - Grid background drawing
 - Mouse wheel zoom
 - Middle-button pan
 - Drag-drop support
 - Selection highlighting
+- Clipboard copy/paste helpers
+
+### i18n Architecture
+
+User-facing UI text uses gettext:
+
+| Component | Location | Responsibility |
+|-----------|----------|----------------|
+| Runtime helpers | `src/ui/i18n.py` | `tr_`, `ngettext`, `pgettext`, and locale installation |
+| Catalog source | `src/locale/messages.pot` | Extracted message template |
+| Translations | `src/locale/<lang>/LC_MESSAGES/messages.po` | Editable translations |
+| Compiled catalogs | `src/locale/<lang>/LC_MESSAGES/messages.mo` | Runtime gettext files |
+| Tooling | `tools/i18n.ps1` | Extract, merge, compile workflow |
+
+Source code should use English msgids wrapped with `tr_(...)`; Simplified Chinese is
+provided by the `zh_CN` catalog rather than hardcoded in Python.
 
 ### Model Builder
 
@@ -780,7 +852,7 @@ Frontend-backend separation (View → Controller → Engine):
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                         UI Layer (Views)                         │
-│  WorkflowView │ ModelBuilderView │ PreviewView │ TrainingView   │
+│  WorkflowTabsView │ ModelBuilderView │ PreviewView │ TrainingView│
 └───────────────────────────┬─────────────────────────────────────┘
                             │ Signal (intra-component)
                             ▼
@@ -794,7 +866,7 @@ Frontend-backend separation (View → Controller → Engine):
                             ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                     Engine/Service Layer                         │
-│  WorkflowEngine │ FeatureExtractor │ TrainerWorker              │
+│  WorkflowEngine │ TrainerWorker │ src/services/                 │
 │  - Pure business logic, no UI dependency                        │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -818,6 +890,7 @@ During workflow execution, nodes display different state markers:
 | completed | Green border | ✅ | Execution complete |
 | error | Red border | ❌ | Execution failed |
 | waiting | Blue border | ⏸️ | Waiting at breakpoint |
+| skipped | Muted/disabled decoration | - | Execution skipped |
 
 ---
 
@@ -877,14 +950,8 @@ Styles.COLORS['green']  # #a6e3a1
 Styles.COLORS['red']    # #f38ba8
 
 # Node colors (by category)
-Styles.NODE_COLORS = {
-    'data_source': '#89b4fa',    # Blue
-    'preprocessing': '#a6e3a1',  # Green
-    'augmentation': '#f9e2af',   # Yellow
-    'feature': '#cba6f7',        # Purple
-    'training': '#f38ba8',       # Red
-    'control': '#94e2d5',        # Cyan
-}
+# Workflow node category colors are defined by NodeCategory.color
+# in src/workflow/node_base.py.
 ```
 
 ---
@@ -938,4 +1005,4 @@ def execute(self) -> bool:
 
 ---
 
-*Last Updated: 2026-01-24*
+*Last Updated: 2026-05-24*

--- a/.cursor/rules/coding_standards.md
+++ b/.cursor/rules/coding_standards.md
@@ -38,6 +38,7 @@ from src.workflow.engine import WorkflowEngine
 - Use `snake_case` for variable names
 - Use `PascalCase` for class names
 - Use `UPPER_SNAKE_CASE` for constants
+- New comments and docstrings must be written in English. Existing Chinese comments/docstrings may be migrated opportunistically when touching nearby code.
 
 ---
 
@@ -48,6 +49,7 @@ from src.workflow.engine import WorkflowEngine
 - Slot functions start with `_on_` or `_handle_`
 - Use `QThread` for time-consuming operations to avoid blocking UI
 - **Unified style management**: Use the `Styles` class from `src/ui/styles.py`
+- Workflow and model editor UI should reuse shared graph editor items from `src/ui/graph_editor/` where practical.
 
 ```python
 from src.ui.styles import Styles
@@ -59,12 +61,28 @@ group.setStyleSheet(Styles.group_box(Styles.COLORS['blue']))
 
 ---
 
+## UI Text and i18n
+
+- Use English source msgids wrapped with `tr_(...)` from `src.ui.i18n` for user-facing strings.
+- Use `ngettext()` for plural text and `pgettext()` when a short msgid needs context.
+- Do not hardcode Simplified Chinese in Python UI code unless the string is intentionally not localized.
+- Update gettext catalogs under `src/locale/` when adding, changing, or removing user-facing strings.
+- Use the `project_managing_i18n` skill for the procedural extract, merge, translate, and compile workflow.
+
+```python
+from src.ui.i18n import tr_
+
+button.setText(tr_("Open workflow"))
+```
+
+---
+
 ## TensorFlow Standards
 
 - Build models using Keras Sequential or Functional API
 - Use custom Callbacks for training process to interact with UI
-- Use `tf.data.Dataset` for data pipeline processing
-- Save models using SavedModel format
+- Use `tf.data.Dataset` when it fits the data pipeline; the current audio training path also uses Keras `Sequence` generators.
+- Save trained models in the format expected by the caller (`.keras`, `.h5`, or SavedModel when explicitly needed).
 
 ---
 
@@ -121,9 +139,29 @@ N_MFCC = 20              # Number of MFCC coefficients
 ## Testing Requirements
 
 - Write unit tests for core functionality
-- Use `pytest-qt` for UI testing
+- The current UI test pattern uses `QT_QPA_PLATFORM=offscreen` and a manual `QApplication.instance() or QApplication([])` setup.
+- Tests currently mix pytest functions and `unittest.TestCase`; follow the surrounding file style unless creating a new focused pytest test.
 - Test audio processing module independently
+- Use the `test_running` and `test_writing` skills for procedural testing guidance.
+
+```python
+import os
+
+from PySide6.QtWidgets import QApplication
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+app = QApplication.instance() or QApplication([])
+```
 
 ---
 
-*Last Updated: 2026-01-24*
+## Dependencies and Tooling
+
+- Runtime dependencies are declared in `requirements.txt`.
+- Current core versions include TensorFlow `>=2.17.0`, PySide6 `>=6.6.0`, NumPy `>=1.26,<2.0`, librosa, soundfile, scipy, resampy, sounddevice, matplotlib, and pyqtgraph.
+- Do not document optional or unused packages as required dependencies unless they are added to `requirements.txt`.
+- No project-level pytest configuration file is currently present; add one only as a deliberate tooling change.
+
+---
+
+*Last Updated: 2026-05-24*

--- a/.cursor/rules/model_json_spec.md
+++ b/.cursor/rules/model_json_spec.md
@@ -31,7 +31,11 @@
 | description | string | ✅ | Model description |
 | created_at | string | ✅ | ISO 8601 timestamp |
 | modified_at | string | ✅ | ISO 8601 timestamp |
-| compile_config | object | ✅ | Compile configuration (redundant field, actually read from Output layer) |
+| compile_config | object | ✅ | Legacy/root compile configuration; used as fallback when no Output layer provides compile settings |
+
+Root metadata is accepted leniently on load: missing `description`, `created_at`, or
+`modified_at` values are filled with defaults by the loader. AI-generated files should
+still include them for readability and repeatability.
 
 ### 1.2 Compile Configuration (compile_config)
 
@@ -49,13 +53,19 @@
 
 **Metric Options**: `accuracy`, `mae`, `mse`, `rmse`, `precision`, `recall`, `auc`, `cosine_similarity`
 
+**Compile precedence**:
+
+1. If an `output` layer exists, runtime model compilation reads optimizer, learning rate, loss, and metrics from that layer's `parameters`.
+2. The root `compile_config` remains part of the saved format for compatibility and fallback.
+3. Saved files can contain a stale root `compile_config` if Output layer settings were changed; prefer keeping both in sync when generating JSON.
+
 ---
 
 ## 2. Node Layout Specification ⭐ Important
 
 ### 2.0 Core Layout Principles 🚨 Must Read
 
-> **⛔ Do NOT arrange all nodes in a single straight line!** This is very unfriendly to users.
+> **⛔ Do NOT arrange all nodes in a single straight line when authoring JSON manually.** This is very unfriendly to users.
 >
 > **✅ Must fully utilize the 2D canvas**, making the network structure clear at a glance.
 
@@ -66,10 +76,15 @@
 3. **Vertical Layering**: Use Y-axis to express network depth or stage changes
 4. **Compact Layout**: Closely related nodes can have smaller spacing (e.g., 120px), larger spacing between stages
 
+Layout rules in this section are authoring guidance for generated `.model.json` files.
+The current serializer/validator does not enforce multi-row layout, semantic IDs, or
+connection ordering. Imported Keras models are initially arranged in a single row by
+`KerasModelParser` and may need manual cleanup.
+
 ### 2.1 Node Dimensions
 
-- **Node width**: ~120px
-- **Node height**: ~60-80px
+- **Node width**: ~180px (`LayerItem.LAYER_WIDTH`)
+- **Node height**: ~60px (`LayerItem.LAYER_HEIGHT`)
 - **Port diameter**: ~12px
 
 ### 2.2 Spacing Specification
@@ -251,7 +266,8 @@ def calculate_unet_position(layer_index: int, total_encoder: int, total_decoder:
   "position": [x, y],
   "parameters": {...},
   "layer_name": "optional_keras_layer_name",
-  "trainable": true
+  "trainable": true,
+  "has_weights": true
 }
 ```
 
@@ -263,6 +279,7 @@ def calculate_unet_position(layer_index: int, total_encoder: int, total_decoder:
 | parameters | object | ✅ | - | Layer parameters |
 | layer_name | string | ❌ | `""` | Keras layer name (optional) |
 | trainable | bool | ❌ | `true` | Whether layer is trainable |
+| has_weights | bool | ❌ | `false` | Whether an imported layer has weights; serialized only when true |
 
 ### 3.2 Trainability Specification 🔧
 
@@ -286,6 +303,27 @@ Examples:
 - "dense_out", "output_01"
 ```
 
+The application can also generate default layer IDs as 8-character UUID hex strings.
+Semantic IDs are preferred for hand-authored or AI-generated JSON because they make
+connections easier to inspect.
+
+### 3.4 Tuple-like Parameter Format
+
+For 2D shapes, reshape targets, pooling sizes, strides, and permutation dimensions,
+the current implementation stores tuple-like values as strings, not JSON arrays.
+
+```json
+{
+  "parameters": {
+    "shape": "(100, 40)",
+    "kernel_size": "(3, 3)",
+    "strides": "(1, 1)",
+    "target_shape": "(64, 1)",
+    "dims": "(2, 1)"
+  }
+}
+```
+
 ---
 
 ## 4. Available Layer Types Quick Reference
@@ -294,7 +332,7 @@ Examples:
 
 | type | Display Name | Parameters |
 |------|--------------|------------|
-| `input` | Input Layer | `shape`: "(H, W)" or "(L, C)", `dtype`: "float32" |
+| `input` | Input Layer | `shape`: "(H, W)" or "(L, C)", `dtype`: "float32", optional `name` |
 | `output` | Output Layer | `activation` (none/linear/sigmoid/softmax/tanh/relu), `optimizer`, `learning_rate`, `loss`, `metrics` |
 
 ### 4.2 Core Layers
@@ -308,11 +346,16 @@ Examples:
 
 | type | Display Name | Main Parameters |
 |------|--------------|-----------------|
-| `conv1d` | Conv1D | `filters`, `kernel_size`, `strides`, `padding`, `activation` |
-| `conv2d` | Conv2D | `filters`, `kernel_size`: "(H,W)", `strides`, `padding` |
+| `conv1d` | Conv1D | `filters`, `kernel_size`, `strides`, `padding` (`valid`/`same`/`causal`), `activation`, `use_bias` |
+| `conv2d` | Conv2D | `filters`, `kernel_size`: "(H,W)", `strides`: "(H,W)", `padding`, `activation`, `use_bias` |
 | `conv1d_transpose` | Conv1DTranspose | Same as conv1d (for upsampling) |
 | `conv2d_transpose` | Conv2DTranspose | Same as conv2d (for upsampling) |
 | `separable_conv1d` | SeparableConv1D | `filters`, `kernel_size`, `strides`, `padding` |
+
+Activation parameter values follow each layer implementation. Dense layers use lowercase
+`"none"` for no activation; Conv2D-family UI defaults may use `"None"` for no activation.
+Prefer explicit activation layers when the visual graph should show Conv/BN/Activation
+as separate stages.
 
 ### 4.4 Pooling Layers
 
@@ -368,17 +411,17 @@ Examples:
 
 | type | Display Name | Main Parameters |
 |------|--------------|-----------------|
-| `lstm` | LSTM | `units`, `return_sequences`, `bidirectional`, `dropout` |
-| `gru` | GRU | `units`, `return_sequences`, `bidirectional`, `dropout` |
-| `simple_rnn` | SimpleRNN | `units`, `return_sequences`, `dropout` |
+| `lstm` | LSTM | `units`, `return_sequences`, `return_state`, `activation`, `recurrent_activation`, `bidirectional`, `dropout`, `recurrent_dropout` |
+| `gru` | GRU | `units`, `return_sequences`, `activation`, `bidirectional`, `dropout`, `recurrent_dropout` |
+| `simple_rnn` | SimpleRNN | `units`, `return_sequences`, `activation`, `dropout` |
 
 ### 4.10 Attention Layers
 
 | type | Display Name | Main Parameters |
 |------|--------------|-----------------|
-| `multi_head_attention` | MultiHeadAttention | `num_heads`, `key_dim`, `value_dim`, `dropout` |
-| `transformer_encoder` | TransformerEncoder | `num_heads`, `key_dim`, `ff_dim`, `dropout_rate`, `activation` |
-| `transformer_decoder` | TransformerDecoder | `num_heads`, `key_dim`, `ff_dim`, `dropout_rate` |
+| `multi_head_attention` | MultiHeadAttention | `num_heads`, `key_dim`, `value_dim`, `dropout`, `use_bias` |
+| `transformer_encoder` | TransformerEncoder | `num_heads`, `key_dim`, `ff_dim`, `dropout_rate`, `activation`, `epsilon`, `pre_norm` |
+| `transformer_decoder` | TransformerDecoder | `num_heads`, `key_dim`, `ff_dim`, `dropout_rate`, `activation` |
 | `positional_encoding` | PositionalEncoding | `max_length`, `encoding_type`, `dropout_rate` |
 | `attention` | Attention | `use_scale`, `score_mode`, `dropout` |
 | `additive_attention` | AdditiveAttention | `use_scale`, `dropout` |
@@ -425,6 +468,32 @@ Arrange in topological order for readability:
   ...
 ]
 ```
+
+The serializer writes connections in insertion order. Topological ordering is strongly
+recommended for hand-authored JSON but is not currently enforced during load or save.
+
+### 5.3 Output Layer Requirement
+
+An explicit `output` layer is recommended because it stores the compile settings used
+by training. The current graph validator only requires at least one terminal layer, so
+a graph ending in `dense` or `softmax` can still validate and build. In that case,
+runtime compilation falls back to root `compile_config`.
+
+### 5.4 Keras Import Notes
+
+`KerasModelParser` maps Keras model layers into model builder layer types where possible.
+Some parser mappings are not currently registered layer types and will be skipped during
+import:
+
+| Keras Layer | Parser Type | Current Status |
+|-------------|-------------|----------------|
+| `SeparableConv2D` | `separable_conv2d` | Not registered |
+| `DepthwiseConv2D` | `depthwise_conv2d` | Not registered |
+| `Bidirectional` | `bidirectional` | Not registered as a standalone layer; LSTM/GRU have a `bidirectional` parameter |
+| `AveragePooling2D` | `avg_pooling2d` | Not registered |
+
+Imported layers with weights are marked with `has_weights: true`; trainability is stored
+with `trainable: false` only when a layer is frozen.
 
 ---
 
@@ -522,10 +591,12 @@ Before generating model JSON, please check:
 **Structure Specification**
 - [ ] All layer IDs unique and semantic
 - [ ] Input layer shape matches task
-- [ ] Output layer contains correct loss and metrics
-- [ ] Connections in topological order
+- [ ] Output layer contains correct loss and metrics, or root `compile_config` is intentionally used as fallback
+- [ ] Root `compile_config` is kept in sync with Output layer parameters when both are present
+- [ ] Connections in topological order for readability
 - [ ] No cyclic connections
 - [ ] Parameter values within valid ranges
+- [ ] Tuple-like 2D parameters are strings, e.g. `"(3, 3)"`, not JSON arrays
 
 **Trainability**
 - [ ] By default all layers trainable (no need to explicitly set trainable)
@@ -676,4 +747,4 @@ Row 3 (y=200): Dense1 → Dropout → Dense2 → Output
 
 ---
 
-*Last Updated: 2026-01-21*
+*Last Updated: 2026-05-24*

--- a/.cursor/rules/rules.mdc
+++ b/.cursor/rules/rules.mdc
@@ -1,4 +1,5 @@
 ---
+description: Core project context and links for the AI Acoustic Signal Training Platform
 alwaysApply: true
 ---
 # AI Acoustic Signal Training Platform - Cursor Rules
@@ -13,9 +14,10 @@ This is a local AI training playground application focused on **acoustic signal 
 |----------|------------|
 | Language | Python 3.10+ |
 | GUI Framework | PySide6 (Catppuccin dark theme) |
-| Deep Learning | TensorFlow 2.15+ / Keras 3.0+ |
-| Audio Processing | librosa, soundfile, scipy, pydub, sounddevice |
+| Deep Learning | TensorFlow 2.17+ / Keras |
+| Audio Processing | librosa, soundfile, scipy, resampy, sounddevice |
 | Visualization | pyqtgraph, matplotlib |
+| i18n | gettext catalogs under `src/locale/` |
 
 ---
 
@@ -27,21 +29,30 @@ This is a local AI training playground application focused on **acoustic signal 
 
 | Document | Description | When to Use |
 |----------|-------------|-------------|
-| [architecture.md](./rules/architecture.md) | Project architecture, directory structure, node system, UI design, design patterns | Before modifying code structure |
-| [coding_standards.md](./rules/coding_standards.md) | Import rules, naming conventions, framework-specific standards | When writing code |
-| [model_json_spec.md](./rules/model_json_spec.md) | Model JSON format specification, layer definitions, layout rules | When generating model files |
+| [architecture.md](./architecture.md) | Project architecture, directory structure, node system, UI design, design patterns | Before modifying code structure |
+| [coding_standards.md](./coding_standards.md) | Import rules, naming conventions, framework-specific standards | When writing code |
+| [model_json_spec.md](./model_json_spec.md) | Model JSON format specification, layer definitions, layout rules | When generating model files |
 
 ### Workflows
 
 | Document | Description | When to Use |
 |----------|-------------|-------------|
-| [git_workflow.md](./workflows/git_workflow.md) | Git branching, commit conventions, PR process | Before making code changes |
+| [git_workflow.md](../workflows/git_workflow.md) | Git branching, commit conventions, PR process | Before making code changes |
 
 ### Skills
 
-| Directory | Description |
-|-----------|-------------|
-| [skills/](./skills/) | Reusable skill definitions for specific tasks |
+| Skill | When to Use |
+|-------|-------------|
+| [code_implementing_features](../skills/code_implementing_features/SKILL.md) | Implementing features or documentation changes after issue/branch setup |
+| [code_fixing_bugs](../skills/code_fixing_bugs/SKILL.md) | Debugging or fixing defects |
+| [project_managing_i18n](../skills/project_managing_i18n/SKILL.md) | Adding or changing user-visible UI text |
+| [git_creating_branch](../skills/git_creating_branch/SKILL.md) | Starting work on a new local branch |
+| [git_pushing_changes](../skills/git_pushing_changes/SKILL.md) | Committing and pushing changes |
+| [git_creating_pr](../skills/git_creating_pr/SKILL.md) | Creating pull requests |
+| [test_running](../skills/test_running/SKILL.md) | Running project tests |
+| [test_writing](../skills/test_writing/SKILL.md) | Writing pytest or unittest tests |
+
+Rules capture durable project facts and constraints. Skills capture step-by-step task procedures; prefer linking to a skill instead of copying long procedural workflows into rules.
 
 ---
 
@@ -51,7 +62,9 @@ This is a local AI training playground application focused on **acoustic signal 
 
 ```
 DT_playground/
-├── main.py                     # Application entry point
+├── main.py                     # Application entry point, logging, splash, i18n bootstrap
+├── requirements.txt            # Runtime dependency list
+├── resources/                  # Icons and optional style assets
 ├── src/
 │   ├── app.py                  # Main application class
 │   ├── core/                   # Core abstraction layer
@@ -61,15 +74,18 @@ DT_playground/
 │   ├── model_builder/          # Visual model builder
 │   ├── training/               # Training module
 │   ├── ui/                     # UI module
+│   ├── services/               # Application services
+│   ├── locale/                 # gettext catalogs
 │   ├── visualization/          # Visualization
 │   └── utils/                  # Utilities
 ├── audio_data/                 # Audio data
 ├── models/                     # Saved models
 ├── workflows/                  # Workflow files
-└── logs/                       # Runtime logs
+├── logs/                       # Runtime logs
+└── tests/                      # Automated tests
 ```
 
-> **Detailed Structure**: See [architecture.md](./rules/architecture.md)
+> **Detailed Structure**: See [architecture.md](./architecture.md)
 
 ---
 
@@ -128,10 +144,11 @@ DT_playground/
 
 ### Software UI
 - **Default UI language**: Chinese (Simplified)
-- **User-facing strings**: Chinese
-- **UI labels, tooltips, and messages**: Chinese
+- **Source UI strings**: English gettext msgids wrapped with `tr_(...)`
+- **Translations**: Chinese and English catalogs under `src/locale/`
+- **UI labels, tooltips, and messages**: Do not hardcode Chinese in Python unless explicitly intentional; update gettext catalogs for user-facing text changes
 
 ---
 
-*For detailed coding standards, see [coding_standards.md](./rules/coding_standards.md)*
-*For architecture details, see [architecture.md](./rules/architecture.md)*
+*For detailed coding standards, see [coding_standards.md](./coding_standards.md)*
+*For architecture details, see [architecture.md](./architecture.md)*

--- a/.cursor/skills/README.md
+++ b/.cursor/skills/README.md
@@ -6,6 +6,12 @@
 
 A **Skill** is a documented set of techniques, patterns, or step-by-step instructions for handling specific types of tasks. Skills are more granular than workflows and focus on "how to do something" rather than "what process to follow".
 
+## Rules vs Skills
+
+- Rules in `.cursor/rules/` describe durable project facts, constraints, architecture, and standards.
+- Skills in `.cursor/skills/` describe task procedures: how to create branches, manage i18n, run tests, write tests, submit issues, or perform debugging.
+- If guidance is mostly a repeatable step-by-step workflow, keep it in a skill and link to it from the relevant rule.
+
 ## Skill Document Format
 
 Each skill document should follow this structure:
@@ -46,13 +52,28 @@ Concrete examples demonstrating the skill.
 
 | Skill | Description | File |
 |-------|-------------|------|
-| *(No skills defined yet)* | | |
+| code_fixing_bugs | Systematic debugging and root cause analysis | [code_fixing_bugs/SKILL.md](code_fixing_bugs/SKILL.md) |
+| code_implementing_features | Feature/documentation implementation workflow | [code_implementing_features/SKILL.md](code_implementing_features/SKILL.md) |
+| data_preparing_labels | Prepare supervised classification labels for audio datasets | [data_preparing_labels/SKILL.md](data_preparing_labels/SKILL.md) |
+| design_brainstorming | Clarify vague requirements before implementation | [design_brainstorming/SKILL.md](design_brainstorming/SKILL.md) |
+| git_creating_branch | Create local personal/task branches | [git_creating_branch/SKILL.md](git_creating_branch/SKILL.md) |
+| git_creating_pr | Create pull requests | [git_creating_pr/SKILL.md](git_creating_pr/SKILL.md) |
+| git_pushing_changes | Commit and push changes safely | [git_pushing_changes/SKILL.md](git_pushing_changes/SKILL.md) |
+| git_submitting_issues | Create structured GitHub issues | [git_submitting_issues/SKILL.md](git_submitting_issues/SKILL.md) |
+| project_managing_i18n | Manage gettext catalog updates | [project_managing_i18n/SKILL.md](project_managing_i18n/SKILL.md) |
+| project_python_init | Initialize Python project scaffolding | [project_python_init/SKILL.md](project_python_init/SKILL.md) |
+| shell_powershell_commands | Run PowerShell commands on Windows | [shell_powershell_commands/SKILL.md](shell_powershell_commands/SKILL.md) |
+| skill_creating_skills | Create or organize project skills | [skill_creating_skills/SKILL.md](skill_creating_skills/SKILL.md) |
+| test_designing | Design test cases and coverage scenarios | [test_designing/SKILL.md](test_designing/SKILL.md) |
+| test_running | Run pytest and analyze test results | [test_running/SKILL.md](test_running/SKILL.md) |
+| test_writing | Write pytest/unit tests | [test_writing/SKILL.md](test_writing/SKILL.md) |
 
 ## Adding New Skills
 
-1. Create a new `.md` file in this directory
-2. Follow the skill document format above
-3. Update this README to include the new skill in the table
+1. Create a folder named with the project convention, e.g. `category_action_target/`.
+2. Add `SKILL.md` with YAML frontmatter and English instructions.
+3. Keep procedural details in the skill; keep stable project constraints in rules.
+4. Update this README to include the new skill in the table.
 
 ---
 

--- a/.cursor/workflows/git_workflow.md
+++ b/.cursor/workflows/git_workflow.md
@@ -6,11 +6,11 @@
 
 ```mermaid
 flowchart TD
-    A[User requests modification] --> B[Read WORKFLOW.md]
+    A[User requests modification] --> B[Read git_workflow.md]
     B --> C["Step 1: Sync code (git fetch)"]
     C --> D{Uncommitted changes or conflicts?}
-    D -->|Yes| E[Prompt user to resolve]
-    D -->|No| F["Step 2: Create feature branch"]
+    D -->|Yes| E[Preserve user changes and discuss if blocking]
+    D -->|No| F["Step 2: Create task branch"]
     F --> G["Step 3: Confirm change plan with user"]
     G --> H{User approved?}
     H -->|No| I[Adjust plan]
@@ -35,44 +35,55 @@ Before making any changes, ensure the local repository is up to date.
 
 ```bash
 # Fetch latest changes from remote
-git fetch origin develop
+git fetch origin
 
 # Check current status
 git status
 
-# If on a stale branch, pull latest develop
-git checkout develop
-git pull origin develop
+# Create new work from the remote base, usually origin/develop
 ```
 
 **If uncommitted changes exist:**
-- Prompt the user to either commit, stash, or discard changes before proceeding.
+- Do not discard or overwrite them.
+- If they are unrelated and do not block the new branch, keep them intact.
+- If they block branch creation or editing, ask the user how to proceed.
 
 **If merge conflicts exist:**
 - Notify the user and assist in resolving conflicts before continuing.
 
 ---
 
-### Step 2: Create Feature Branch
+### Step 2: Create Task Branch
 
 Create a new branch following the naming convention.
 
 **Branch Naming Format:**
 ```
-feature/<username>/<feature-description>
+{type}/{issue_id?}_{short_description}
 ```
 
+**Branch Types:**
+| Type | Use For |
+|------|---------|
+| `feature` | New functionality |
+| `bugfix` | Bug fixes |
+| `hotfix` | Urgent fixes |
+| `refactor` | Refactoring |
+| `docs` | Documentation updates |
+| `test` | Test additions or changes |
+
 **Examples:**
-- `feature/gyy/add-audio-preprocessing`
-- `feature/john/fix-training-callback`
-- `feature/alice/refactor-workflow-engine`
+- `docs/TASK2026052401_cursor_rules_refresh`
+- `feature/FEAT2026050601_label_file_preview`
+- `bugfix/BUG2026050901_training_callback_error`
 
 **Commands:**
 ```bash
-# Create and switch to new branch from develop
-git checkout develop
-git checkout -b feature/<username>/<description>
+# Create and switch to new branch from the remote develop base
+git checkout -b {branch_name} origin/develop
 ```
+
+Use the `git_creating_branch` skill for the detailed branch creation procedure.
 
 ---
 
@@ -81,7 +92,7 @@ git checkout -b feature/<username>/<description>
 Before implementing any changes, the AI agent must:
 
 1. **Analyze the request** - Understand what the user wants to achieve
-2. **Create a plan** - Use Cursor's Plan Mode / `create_plan` tool
+2. **Create a plan when needed** - Use Cursor Plan Mode for broad, ambiguous, or cross-cutting changes
 3. **Present the plan** - Show the user:
    - Files to be modified
    - Summary of changes
@@ -101,6 +112,7 @@ Follow the project's coding standards defined in [coding_standards.md](../rules/
 - Write docstrings in English
 - Follow the import order convention
 - Respect the MVC + Controller architecture
+- Keep procedural task details in skills and durable project constraints in rules
 
 ---
 
@@ -117,13 +129,14 @@ pytest tests/
 pytest tests/test_<module>.py
 ```
 
-For UI changes, use browser tools to verify functionality if applicable.
+For desktop PySide6 UI changes, prefer automated offscreen Qt tests or manual app verification. Browser tools are not the primary verification path for this desktop application.
 
 ---
 
 ### Step 6: Commit Changes
 
 Use **Conventional Commits** format for all commit messages.
+Commit messages must be written in English.
 
 **Format:**
 ```
@@ -163,11 +176,12 @@ If yes:
 
 **Push to remote:**
 ```bash
-git push -u origin feature/<username>/<description>
+git push -u origin <branch>
 ```
 
 **Create Pull Request:**
 - Target branch: `develop`
+- Use GitHub CLI (`gh pr create`) when creating PRs from the agent
 - Use the PR template below
 
 ---
@@ -221,6 +235,19 @@ If any sensitive information is detected, alert the user immediately.
 
 ---
 
+## Protected Branches
+
+Do not commit or push directly to protected long-lived branches:
+
+- `main`
+- `master`
+- `develop`
+- `release/*`
+
+Use a personal/task branch and open a PR instead.
+
+---
+
 ## Conflict Resolution
 
 If conflicts are detected during sync or merge:
@@ -240,20 +267,15 @@ If conflicts are detected during sync or merge:
 If changes need to be reverted:
 
 ```bash
-# Discard uncommitted changes
-git checkout -- .
-
 # Revert last commit (keep changes staged)
 git reset --soft HEAD~1
-
-# Revert last commit (discard changes)
-git reset --hard HEAD~1
 
 # Revert a specific commit
 git revert <commit-hash>
 ```
 
-Always confirm with the user before performing any destructive operations.
+Never discard uncommitted changes, run `git checkout --`, or run `git reset --hard`
+unless the user explicitly requests that exact destructive operation after being warned.
 
 ---
 
@@ -261,8 +283,8 @@ Always confirm with the user before performing any destructive operations.
 
 | Action | Command |
 |--------|---------|
-| Sync code | `git fetch origin develop` |
-| Create branch | `git checkout -b feature/<user>/<desc>` |
+| Sync code | `git fetch origin` |
+| Create branch | `git checkout -b docs/TASK2026052401_description origin/develop` |
 | Stage all | `git add .` |
 | Commit | `git commit -m "type(scope): message"` |
 | Push | `git push -u origin <branch>` |
@@ -274,7 +296,10 @@ Always confirm with the user before performing any destructive operations.
 
 ## Related Documents
 
-- [rules.mdc](../rules.mdc) - Project rules entry point
+- [rules.mdc](../rules/rules.mdc) - Project rules entry point
 - [architecture.md](../rules/architecture.md) - Project architecture documentation
 - [coding_standards.md](../rules/coding_standards.md) - Coding standards
 - [model_json_spec.md](../rules/model_json_spec.md) - Model JSON specification
+- [git_creating_branch](../skills/git_creating_branch/SKILL.md) - Branch creation procedure
+- [git_pushing_changes](../skills/git_pushing_changes/SKILL.md) - Commit and push procedure
+- [git_creating_pr](../skills/git_creating_pr/SKILL.md) - Pull request creation procedure


### PR DESCRIPTION
## Summary
- Refresh Cursor rules, architecture, coding standards, model JSON spec, and Git workflow docs to match the current project structure.
- Clarify the boundary between durable project rules and procedural skills, and update the skills index.
- Move the Cursor rules entry point under `.cursor/rules/rules.mdc` while preserving working relative links.

## Related Issue
Closes #106

## Changes
- `.cursor/rules/`: Updated rule entry point, architecture reference, coding standards, and model JSON specification.
- `.cursor/workflows/git_workflow.md`: Reconciled branch, commit, PR, and safety guidance with project git skills.
- `.cursor/skills/README.md`: Listed current skills and documented rules-vs-skills placement.

## Test Plan
- [x] Ran markdown local link validation for edited docs.
- [x] Ran `git diff --check`.
- [x] Confirmed IDE lints reported no diagnostics for edited docs.

## Checklist
- [x] Documentation updated.
- [x] Self-review completed.
- [x] No runtime code changes included.

Made with [Cursor](https://cursor.com)